### PR TITLE
Upgrade dewey to v0.0.1, unblock BATS tests (blocked on purse-first#39/#40)

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/amarbel-llc/bob/packages/tap-dancer/go v0.1.0
-	github.com/amarbel-llc/purse-first/libs/dewey v0.0.0-20260412143445-31147ce442d7
+	github.com/amarbel-llc/purse-first/libs/dewey v0.0.1
 	github.com/amarbel-llc/purse-first/libs/go-mcp v0.0.12
 	github.com/amarbel-llc/tommy v0.0.0-20260405143331-87255e87bf37
 	github.com/brandondube/tai v0.1.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -10,8 +10,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/amarbel-llc/bob/packages/tap-dancer/go v0.1.0 h1:+8QbL84Q9IVcKUPm0DJ4emTwXndujB86ATqyNCem+KQ=
 github.com/amarbel-llc/bob/packages/tap-dancer/go v0.1.0/go.mod h1:f/eBRNyz3TVY+bB5bnNmYioJEgNrmwbvscFq29VFyXc=
-github.com/amarbel-llc/purse-first/libs/dewey v0.0.0-20260412143445-31147ce442d7 h1:tGPmxzOswBSJ8CGcOBUKPTnTVKl6ImbFUh+LpILWKeY=
-github.com/amarbel-llc/purse-first/libs/dewey v0.0.0-20260412143445-31147ce442d7/go.mod h1:St7g+dt6IXHvkPOWaDto5qk+LJrALrWiDR6WLJdBnAE=
+github.com/amarbel-llc/purse-first/libs/dewey v0.0.1 h1:sCoPB/vKqcafWaa/fkhD6Pk79O7qIwuNzJc48wIXcpM=
+github.com/amarbel-llc/purse-first/libs/dewey v0.0.1/go.mod h1:St7g+dt6IXHvkPOWaDto5qk+LJrALrWiDR6WLJdBnAE=
 github.com/amarbel-llc/purse-first/libs/go-mcp v0.0.12 h1:vAuX5weS0oDmbA4d+Y+FQdIKjFZDInUtANnZmFOqR9c=
 github.com/amarbel-llc/purse-first/libs/go-mcp v0.0.12/go.mod h1:4QNwpEtQWg+aF++9BpxQq93cnj6puQfsARZ0Z4fHIHk=
 github.com/amarbel-llc/tommy v0.0.0-20260405143331-87255e87bf37 h1:OQA0sRnQMO5c4qcOXdxp0mKQMWIEcs9yvPfkoXafMtQ=

--- a/go/gomod2nix.toml
+++ b/go/gomod2nix.toml
@@ -22,8 +22,8 @@ schema = 3
     goVersion = '1.26'
 
   [mod.'github.com/amarbel-llc/purse-first/libs/dewey']
-    version = 'v0.0.0-20260412143445-31147ce442d7'
-    hash = 'sha256-DY+ke/Bn0CmJKyuqX68khjqXFehwdloyMONR3B2z/kY='
+    version = 'v0.0.1'
+    hash = 'sha256-d76ofGscwjMCpO9jIO77ehWXn2qMQlVdotLOs/+ZCTk='
     goVersion = '1.26'
 
   [mod.'github.com/amarbel-llc/purse-first/libs/go-mcp']

--- a/zz-tests_bats/fsck.bats
+++ b/zz-tests_bats/fsck.bats
@@ -6,7 +6,7 @@ setup() {
 # bats file_tags=fsck
 
 function tap14_output { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
   run_madder fsck
@@ -17,7 +17,7 @@ function tap14_output { # @test
 }
 
 function with_blobs { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
 

--- a/zz-tests_bats/info_repo.bats
+++ b/zz-tests_bats/info_repo.bats
@@ -6,7 +6,7 @@ setup() {
 # bats file_tags=info_repo
 
 function compression_type { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
   run_madder info-repo compression-type
@@ -15,7 +15,7 @@ function compression_type { # @test
 }
 
 function encryption_none { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
   run_madder info-repo encryption
@@ -24,7 +24,7 @@ function encryption_none { # @test
 }
 
 function unknown_key_fails { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
   run_madder info-repo nonexistent-key

--- a/zz-tests_bats/init.bats
+++ b/zz-tests_bats/init.bats
@@ -6,19 +6,19 @@ setup() {
 # bats file_tags=init
 
 function init_default { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   init_store
 }
 
 function init_idempotent_fails { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   init_store
   run_madder init -encryption none -lock-internal-files=false .default
   assert_failure
 }
 
 function init_compression_default { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
   run_madder info-repo compression-type
@@ -26,7 +26,7 @@ function init_compression_default { # @test
 }
 
 function init_without_encryption { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
   run_madder info-repo encryption
@@ -34,7 +34,7 @@ function init_without_encryption { # @test
 }
 
 function init_with_encryption { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   run_madder init -encryption generate .encrypted
   assert_success
@@ -44,7 +44,7 @@ function init_with_encryption { # @test
 }
 
 function init_inventory_archive { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
   run_madder init-inventory-archive -encryption none .archive
@@ -52,7 +52,7 @@ function init_inventory_archive { # @test
 }
 
 function init_inventory_archive_with_encryption { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
   run_madder init-inventory-archive -encryption generate .archive

--- a/zz-tests_bats/pack.bats
+++ b/zz-tests_bats/pack.bats
@@ -43,7 +43,7 @@ shared_blob_prefix() {
 }
 
 function pack_with_delta { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
   create_archive_config "archive" "true"
@@ -95,7 +95,7 @@ function pack_with_delta { # @test
 }
 
 function pack_without_delta { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
   create_archive_config "archive" "false"

--- a/zz-tests_bats/sync.bats
+++ b/zz-tests_bats/sync.bats
@@ -6,7 +6,7 @@ setup() {
 # bats file_tags=sync
 
 function cross_hash_sync { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
 
@@ -32,7 +32,7 @@ function cross_hash_sync { # @test
 }
 
 function sync_idempotent { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
 

--- a/zz-tests_bats/write_read.bats
+++ b/zz-tests_bats/write_read.bats
@@ -6,7 +6,7 @@ setup() {
 # bats file_tags=write,read
 
 function write_and_cat { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
 
@@ -24,7 +24,7 @@ function write_and_cat { # @test
 }
 
 function write_from_stdin { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
 
@@ -36,7 +36,7 @@ function write_from_stdin { # @test
 }
 
 function list_after_write { # @test
-  skip "blocked on dewey golf/command bug (madder#2, purse-first#38)"
+  skip "blocked on dewey AddCmd bugs (purse-first#39, purse-first#40)"
   set_xdg "$BATS_TEST_TMPDIR"
   init_store
 


### PR DESCRIPTION
Upgrades `purse-first/libs/dewey` from pseudo-version to v0.0.1. The original blocker (#2 / purse-first#38: `PopArg` not populated in `AddCmd`) is fixed in v0.0.1, but testing revealed two additional dewey bugs:

## New upstream blockers

- **purse-first#39**: `AddCmd` doesn't parse flags before positional args — `madder init -encryption none .default` treats `-encryption` as the positional arg instead of `.default`
- **purse-first#40**: `AddCmd` doesn't recover `ContextState` panics from `Cancel` — the `Cancel` → `ContextContinueOrPanic` unwind pattern requires a `recover` in `runRetry`, but `AddCmd` calls `cmd.Run(req)` directly without that wrapper

## What's in this PR

- Dewey dependency upgraded to v0.0.1
- All 19 init-dependent BATS test skips updated from `purse-first#38` references to `purse-first#39, purse-first#40`
- MCP tests (2) continue to pass

## To complete (after upstream fixes)

Remove all `skip` lines and verify the full suite passes.

---
:clown: [Clown](https://github.com/amarbel-llc/clown)