### PR TITLE
feat: migrate to amarbel-llc/nixpkgs fork, drop gomod2nix input (closes #40)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776080628,
-        "narHash": "sha256-rRBm4VTzBS/zym3bh4PkW3EfloeI2vcAdOOYrVb+MkU=",
+        "lastModified": 1776891116,
+        "narHash": "sha256-jF9rEPahajLrpbwculYu5SN2t+Ebd93dD8hoCnPUNeA=",
         "owner": "amarbel-llc",
         "repo": "bob",
-        "rev": "d10487340689a8eb0f06725956025ef315305d9e",
+        "rev": "1b5a0c57f302996c26c1af0093d4867fc7304e93",
         "type": "github"
       },
       "original": {
@@ -42,8 +42,7 @@
           "purse-first",
           "crane"
         ],
-        "fh": "fh_2",
-        "gomod2nix": "gomod2nix_5",
+        "gomod2nix": "gomod2nix_4",
         "nixpkgs": [
           "tommy",
           "nixpkgs"
@@ -60,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773681009,
-        "narHash": "sha256-GHhTUg9NT83T4lypcEiDoPstkilug8K5W7KrpHcPHAY=",
+        "lastModified": 1776891116,
+        "narHash": "sha256-jF9rEPahajLrpbwculYu5SN2t+Ebd93dD8hoCnPUNeA=",
         "owner": "amarbel-llc",
         "repo": "bob",
-        "rev": "7fc276940129eae9a03ff112363b0e5d249c4b13",
+        "rev": "1b5a0c57f302996c26c1af0093d4867fc7304e93",
         "type": "github"
       },
       "original": {
@@ -119,34 +118,20 @@
     },
     "crane_4": {
       "locked": {
-        "lastModified": 1758758545,
-        "narHash": "sha256-NU5WaEdfwF6i8faJ2Yh+jcK9vVFrofLcwlD/mP65JrI=",
-        "rev": "95d528a5f54eaba0d12102249ce42f4d01f4e364",
-        "revCount": 764,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/ipetkov/crane/0.21.1/01997e40-19a9-7bc6-9dba-0585d6ed9a98/source.tar.gz"
+        "lastModified": 1773857772,
+        "narHash": "sha256-5xsK26KRHf0WytBtsBnQYC/lTWDhQuT57HJ7SzuqZcM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "b556d7bbae5ff86e378451511873dfd07e4504cd",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/ipetkov/crane/0"
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
       }
     },
     "crane_5": {
-      "locked": {
-        "lastModified": 1773189535,
-        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_6": {
       "locked": {
         "lastModified": 1758758545,
         "narHash": "sha256-NU5WaEdfwF6i8faJ2Yh+jcK9vVFrofLcwlD/mP65JrI=",
@@ -188,34 +173,11 @@
         "nixpkgs": [
           "tommy",
           "bob",
-          "fh",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src_2"
-      },
-      "locked": {
-        "lastModified": 1756709111,
-        "narHash": "sha256-xv2u5dnQpdWkrIy5TBSomr055odWtRSoECSGBzNpp3w=",
-        "rev": "113eba389317407992ea219d5aaced44bf6407f9",
-        "revCount": 2375,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2375%2Brev-113eba389317407992ea219d5aaced44bf6407f9/0199045f-8452-723d-b201-deb22d41c75e/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/nix-community/fenix/%3D0.1.2375"
-      }
-    },
-    "fenix_3": {
-      "inputs": {
-        "nixpkgs": [
-          "tommy",
-          "bob",
           "purse-first",
           "fh",
           "nixpkgs"
         ],
-        "rust-analyzer-src": "rust-analyzer-src_3"
+        "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
         "lastModified": 1756709111,
@@ -251,28 +213,9 @@
     },
     "fh_2": {
       "inputs": {
-        "crane": "crane_4",
+        "crane": "crane_5",
         "fenix": "fenix_2",
         "nixpkgs": "nixpkgs_4"
-      },
-      "locked": {
-        "lastModified": 1761780713,
-        "narHash": "sha256-EUCV7/J9wJRroCGW5JqonFJIqcvJEBAwB7l3eWYxiSk=",
-        "rev": "4f001f2e1de4776f01cf22d1de815f1016a4c4c9",
-        "revCount": 786,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/fh/0.1.27/019a355b-4c74-769d-a9ad-232df447089d/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/fh/%2A.tar.gz"
-      }
-    },
-    "fh_3": {
-      "inputs": {
-        "crane": "crane_6",
-        "fenix": "fenix_3",
-        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1761780713,
@@ -359,24 +302,6 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
-      "inputs": {
-        "systems": "systems_6"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "gomod2nix": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -386,15 +311,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1770585520,
-        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
-        "owner": "nix-community",
+        "lastModified": 1775655738,
+        "narHash": "sha256-fK9KNU9oNugFyGu8uqv1OM4anYFVcIeYVntuaUFx4Y0=",
+        "owner": "amarbel-llc",
         "repo": "gomod2nix",
-        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
+        "rev": "c721288259a04d29966f38d5baa3d3b30bf8fe08",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "amarbel-llc",
         "repo": "gomod2nix",
         "type": "github"
       }
@@ -424,9 +349,13 @@
     },
     "gomod2nix_3": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": [
+          "purse-first",
+          "utils"
+        ],
         "nixpkgs": [
-          "nixpkgs-master"
+          "purse-first",
+          "nixpkgs"
         ]
       },
       "locked": {
@@ -445,12 +374,10 @@
     },
     "gomod2nix_4": {
       "inputs": {
-        "flake-utils": [
-          "purse-first",
-          "utils"
-        ],
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
-          "purse-first",
+          "tommy",
+          "bob",
           "nixpkgs"
         ]
       },
@@ -474,68 +401,20 @@
         "nixpkgs": [
           "tommy",
           "bob",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770585520,
-        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
-    "gomod2nix_6": {
-      "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": [
-          "tommy",
-          "bob",
           "purse-first",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1770585520,
-        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
-        "owner": "nix-community",
+        "lastModified": 1775655738,
+        "narHash": "sha256-fK9KNU9oNugFyGu8uqv1OM4anYFVcIeYVntuaUFx4Y0=",
+        "owner": "amarbel-llc",
         "repo": "gomod2nix",
-        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
+        "rev": "c721288259a04d29966f38d5baa3d3b30bf8fe08",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
-    "gomod2nix_7": {
-      "inputs": {
-        "flake-utils": [
-          "tommy",
-          "utils"
-        ],
-        "nixpkgs": [
-          "tommy",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770585520,
-        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
+        "owner": "amarbel-llc",
         "repo": "gomod2nix",
         "type": "github"
       }
@@ -588,17 +467,17 @@
     },
     "nixpkgs-master_3": {
       "locked": {
-        "lastModified": 1773486025,
-        "narHash": "sha256-ea+4Zg0lMGErMGZrgkg25c9fiGzMmHStyBjwH1xJFFw=",
+        "lastModified": 1774366223,
+        "narHash": "sha256-EkNxFNHtu8q9oUcmcaQk/fsNrErrAMUMx4uMN5qjDIM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e034e386767a6d00b65ac951821835bd977a08f7",
+        "rev": "e2dde111aea2c0699531dc616112a96cd55ab8b5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e034e386767a6d00b65ac951821835bd977a08f7",
+        "rev": "e2dde111aea2c0699531dc616112a96cd55ab8b5",
         "type": "github"
       }
     },
@@ -636,17 +515,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1774244481,
-        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
-        "owner": "NixOS",
+        "lastModified": 1776972814,
+        "narHash": "sha256-pDxMOoUe5adO6xttvuXWh7AcesS8gkZjTxZ+9ZVjJFQ=",
+        "owner": "amarbel-llc",
         "repo": "nixpkgs",
-        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
+        "rev": "b75a0d7f1e0872bf93a4295dc7fa44267c8b9555",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "amarbel-llc",
         "repo": "nixpkgs",
-        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
         "type": "github"
       }
     },
@@ -666,36 +544,6 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1761468971,
-        "narHash": "sha256-vY2OLVg5ZTobdroQKQQSipSIkHlxOTrIF1fsMzPh8w8=",
-        "rev": "78e34d1667d32d8a0ffc3eba4591ff256e80576e",
-        "revCount": 811770,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.811770%2Brev-78e34d1667d32d8a0ffc3eba4591ff256e80576e/019a23fb-89f0-7302-a573-f6bf7dde9cf5/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1773375660,
-        "narHash": "sha256-SEzUWw2Rf5Ki3bcM26nSKgbeoqi2uYy8IHVBqOKjX3w=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3e20095fe3c6cbb1ddcef89b26969a69a1570776",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3e20095fe3c6cbb1ddcef89b26969a69a1570776",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
         "lastModified": 1774244481,
         "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
         "owner": "NixOS",
@@ -707,6 +555,21 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "4590696c8693fea477850fe379a01544293ca4e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1776972814,
+        "narHash": "sha256-pDxMOoUe5adO6xttvuXWh7AcesS8gkZjTxZ+9ZVjJFQ=",
+        "owner": "amarbel-llc",
+        "repo": "nixpkgs",
+        "rev": "b75a0d7f1e0872bf93a4295dc7fa44267c8b9555",
+        "type": "github"
+      },
+      "original": {
+        "owner": "amarbel-llc",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -737,7 +600,7 @@
     "purse-first_2": {
       "inputs": {
         "crane": "crane_3",
-        "gomod2nix": "gomod2nix_4",
+        "gomod2nix": "gomod2nix_3",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -750,11 +613,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776448581,
-        "narHash": "sha256-AQtYVi7c4HC243WlMsES0u0+tP4UsvYQDZ23rsgmDAI=",
+        "lastModified": 1776527448,
+        "narHash": "sha256-aEpPFa0j+D4YMzSCKmnlXjOflHFM+4DLZx0UZGjlV8g=",
         "owner": "amarbel-llc",
         "repo": "purse-first",
-        "rev": "01bfbd3a34ac9e38349f3bea354868c89e858f4e",
+        "rev": "3ed4437dbc65dd0699abe9135f4c210030af9d9b",
         "type": "github"
       },
       "original": {
@@ -765,20 +628,20 @@
     },
     "purse-first_3": {
       "inputs": {
-        "crane": "crane_5",
-        "fh": "fh_3",
-        "gomod2nix": "gomod2nix_6",
-        "nixpkgs": "nixpkgs_6",
+        "crane": "crane_4",
+        "fh": "fh_2",
+        "gomod2nix": "gomod2nix_5",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-master": "nixpkgs-master_3",
         "rust-overlay": "rust-overlay_4",
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1773502101,
-        "narHash": "sha256-KPiapcccC8u9ZMMXpYuBhwIq3gBGoONhwQlWX9yGppo=",
+        "lastModified": 1775656151,
+        "narHash": "sha256-65xohdP2kM1Ob/jgtD2XbrjZexY0VHaGGQtHm8Nqfwg=",
         "owner": "amarbel-llc",
         "repo": "purse-first",
-        "rev": "e2d850e29bdbe782f107d82c0430f298b521fbfe",
+        "rev": "69a41af6c95b440929e848c907f125fdfa8d29d1",
         "type": "github"
       },
       "original": {
@@ -790,7 +653,6 @@
     "root": {
       "inputs": {
         "bob": "bob",
-        "gomod2nix": "gomod2nix_3",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-master": "nixpkgs-master_2",
         "purse-first": "purse-first_2",
@@ -816,23 +678,6 @@
       }
     },
     "rust-analyzer-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1756597274,
-        "narHash": "sha256-wfaKRKsEVQDB7pQtAt04vRgFphkVscGRpSx3wG1l50E=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "21614ed2d3279a9aa1f15c88d293e65a98991b30",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "rust-analyzer-src_3": {
       "flake": false,
       "locked": {
         "lastModified": 1756597274,
@@ -923,11 +768,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773457417,
-        "narHash": "sha256-waABTSxPdbxml4BhcabHhyQF02Qnj27qRU4ard0mTQo=",
+        "lastModified": 1773975983,
+        "narHash": "sha256-zrRVwdfhDdohANqEhzY/ydeza6EXEi8AG6cyMRNYT9Q=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "055977c30249484010750e03074c744dcdaa0d23",
+        "rev": "cc80954a95f6f356c303ed9f08d0b63ca86216ac",
         "type": "github"
       },
       "original": {
@@ -945,11 +790,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773457417,
-        "narHash": "sha256-waABTSxPdbxml4BhcabHhyQF02Qnj27qRU4ard0mTQo=",
+        "lastModified": 1774321696,
+        "narHash": "sha256-g18xMjMNla/nsF5XyQCNyWmtb2UlZpkY0XE8KinIXAA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "055977c30249484010750e03074c744dcdaa0d23",
+        "rev": "49a67e6894d4cb782842ee6faa466aa90c92812d",
         "type": "github"
       },
       "original": {
@@ -1063,37 +908,21 @@
         "type": "github"
       }
     },
-    "systems_8": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "tommy": {
       "inputs": {
         "bob": "bob_2",
-        "gomod2nix": "gomod2nix_7",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-master": "nixpkgs-master_4",
         "utils": [
           "utils"
         ]
       },
       "locked": {
-        "lastModified": 1775399611,
-        "narHash": "sha256-ElzACYuPmWpNk7bm4V8de18P+PqG+92X9aSxJg8gRUI=",
+        "lastModified": 1776973065,
+        "narHash": "sha256-qV9eENXxLHS0ybgzuFJmEsi/0n76HrdcCj2csh9UNOM=",
         "owner": "amarbel-llc",
         "repo": "tommy",
-        "rev": "87255e87bf372148f2b17a5514eb73f8a84e0ac4",
+        "rev": "3fbe2933b83fbbf009392f8f00a01bfd0eb26c76",
         "type": "github"
       },
       "original": {
@@ -1121,7 +950,7 @@
     },
     "utils_2": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1138,7 +967,7 @@
     },
     "utils_3": {
       "inputs": {
-        "systems": "systems_8"
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1731533236,

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,8 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/4590696c8693fea477850fe379a01544293ca4e2";
+    nixpkgs.url = "github:amarbel-llc/nixpkgs";
     nixpkgs-master.url = "github:NixOS/nixpkgs/e2dde111aea2c0699531dc616112a96cd55ab8b5";
     utils.url = "https://flakehub.com/f/numtide/flake-utils/0.1.102";
-
-    gomod2nix = {
-      url = "github:amarbel-llc/gomod2nix";
-      inputs.nixpkgs.follows = "nixpkgs-master";
-    };
 
     tommy = {
       url = "github:amarbel-llc/tommy";
@@ -35,29 +30,22 @@
       nixpkgs,
       nixpkgs-master,
       utils,
-      gomod2nix,
       tommy,
       bob,
       purse-first,
       ...
     }:
     let
-      # Burnt into the binary via -ldflags. Single source of truth for
-      # the release version; `just bump-version` sed-rewrites this line.
       madderVersion = "0.1.0";
-      # shortRev for clean builds, dirtyShortRev for dirty working trees
-      # (so devshell builds show `dirty-abcdef` rather than masquerading
-      # as a clean release), "unknown" as a last-resort fallback.
-      madderCommit = self.shortRev or self.dirtyShortRev or "unknown";
     in
     (utils.lib.eachDefaultSystem (
       system:
       let
         result = import ./go/default.nix {
           inherit
+            self
             nixpkgs
             nixpkgs-master
-            gomod2nix
             tommy
             bob
             purse-first
@@ -65,7 +53,6 @@
             ;
           man7Src = ./docs/man.7;
           version = madderVersion;
-          commit = madderCommit;
         };
       in
       {

--- a/go/cmd/madder-cache/main.go
+++ b/go/cmd/madder-cache/main.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"github.com/amarbel-llc/madder/go/internal/0/buildinfo"
 	"github.com/amarbel-llc/madder/go/internal/charlie/cli_main"
 	"github.com/amarbel-llc/madder/go/internal/india/commands_cache"
 )
+
+var version = "dev"
+var commit  = "unknown"
+
+func init() {
+	buildinfo.Set(version, commit)
+}
 
 func main() {
 	cli_main.Run(commands_cache.GetUtility(), "madder-cache")

--- a/go/cmd/madder-gen_man/main.go
+++ b/go/cmd/madder-gen_man/main.go
@@ -4,10 +4,18 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/amarbel-llc/madder/go/internal/0/buildinfo"
 	"github.com/amarbel-llc/madder/go/internal/futility"
 	"github.com/amarbel-llc/madder/go/internal/india/commands"
 	"github.com/amarbel-llc/madder/go/internal/india/commands_cache"
 )
+
+var version = "dev"
+var commit  = "unknown"
+
+func init() {
+	buildinfo.Set(version, commit)
+}
 
 func main() {
 	if len(os.Args) < 2 {

--- a/go/cmd/madder/main.go
+++ b/go/cmd/madder/main.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"github.com/amarbel-llc/madder/go/internal/0/buildinfo"
 	"github.com/amarbel-llc/madder/go/internal/charlie/cli_main"
 	"github.com/amarbel-llc/madder/go/internal/india/commands"
 )
+
+var version = "dev"
+var commit  = "unknown"
+
+func init() {
+	buildinfo.Set(version, commit)
+}
 
 func main() {
 	cli_main.Run(commands.GetUtility(), "madder")

--- a/go/default.nix
+++ b/go/default.nix
@@ -20,7 +20,7 @@ let
     pname = "madder";
     inherit version;
     commit = self.shortRev or self.dirtyShortRev or "unknown";
-    src = self;
+    src = ./go;
     pwd = ./.;
     subPackages = [
       "cmd/madder"

--- a/go/default.nix
+++ b/go/default.nix
@@ -20,7 +20,7 @@ let
     pname = "madder";
     inherit version;
     commit = self.shortRev or self.dirtyShortRev or "unknown";
-    src = ./go;
+    src = self;
     pwd = ./.;
     subPackages = [
       "cmd/madder"

--- a/go/default.nix
+++ b/go/default.nix
@@ -1,36 +1,26 @@
 {
+  self,
   nixpkgs,
   nixpkgs-master,
   tommy,
-  gomod2nix,
   bob,
   purse-first,
   system,
   man7Src ? null,
-  # Burnt into every binary via -ldflags. Defaulted so that
-  # non-flake consumers (e.g. direct `import ./go/default.nix`) still
-  # work, but release builds always override via flake.nix.
   version ? "dev",
-  commit ? "unknown",
 }:
 let
-  pkgs = import nixpkgs {
-    inherit system;
-    overlays = [
-      gomod2nix.overlays.default
-    ];
-  };
+  pkgs = import nixpkgs { inherit system; };
 
   pkgs-master = import nixpkgs-master {
     inherit system;
   };
 
-  buildinfoPkg = "github.com/amarbel-llc/madder/go/internal/0/buildinfo";
-
   madder = pkgs.buildGoApplication {
     pname = "madder";
     inherit version;
-    src = ./.;
+    commit = self.shortRev or self.dirtyShortRev or "unknown";
+    src = self;
     pwd = ./.;
     subPackages = [
       "cmd/madder"
@@ -40,13 +30,6 @@ let
     modules = ./gomod2nix.toml;
     go = pkgs-master.go_1_26;
     GOTOOLCHAIN = "local";
-
-    ldflags = [
-      "-X"
-      "${buildinfoPkg}.Version=${version}"
-      "-X"
-      "${buildinfoPkg}.Commit=${commit}"
-    ];
 
     nativeBuildInputs = [
       purse-first.packages.${system}.dagnabit
@@ -58,7 +41,6 @@ let
       dagnabit export
     '';
 
-    # madder-gen_man takes a *prefix* and writes to {prefix}/share/man/man1/
     postInstall = ''
       $out/bin/madder-gen_man $out
       rm $out/bin/madder-gen_man
@@ -81,14 +63,13 @@ in
 
   devShells.default = pkgs-master.mkShell {
     packages = [
-      gomod2nix.packages.${system}.default
+      (pkgs.mkGoEnv { pwd = ./.; go = pkgs-master.go_1_26; })
       tommy.packages.${system}.default
       bob.packages.${system}.batman
       purse-first.packages.${system}.dagnabit
     ]
     ++ (with pkgs-master; [
       delve
-      go_1_26
       gofumpt
       gopls
       gotools

--- a/go/internal/0/buildinfo/buildinfo.go
+++ b/go/internal/0/buildinfo/buildinfo.go
@@ -1,31 +1,13 @@
-// Package buildinfo exposes the version and commit SHA that were burnt
-// into the binary at build time via -ldflags. Nix builds override these
-// values from flake.nix (madderVersion + self.shortRev); plain `go build`
-// in the devshell leaves them at their defaults so local debugging is
-// immediately distinguishable from an installed release.
-//
-// The `version` subcommand is the canonical consumer; any future code
-// that needs to report build identity (e.g. a User-Agent header, an MCP
-// initialize response, a crash-report footer) should also read from
-// here rather than hardcoding a second string.
 package buildinfo
 
-// Version is the semver or "dev" for non-release builds. Overridden at
-// link time via:
-//
-//	-X github.com/amarbel-llc/madder/go/internal/0/buildinfo.Version=<v>
 var Version = "dev"
+var Commit  = "unknown"
 
-// Commit is the short git SHA or "unknown". Nix builds populate it from
-// `self.shortRev or self.dirtyShortRev or "unknown"`, so a dirty local
-// build shows `dirty-abcdef` rather than an undifferentiated "dev".
-// Overridden at link time via:
-//
-//	-X github.com/amarbel-llc/madder/go/internal/0/buildinfo.Commit=<sha>
-var Commit = "unknown"
+func Set(v, c string) {
+	Version = v
+	Commit  = c
+}
 
-// String returns "Version+Commit" — the canonical one-line build
-// identity, matching moxy's convention (cmd/moxy/main.go).
 func String() string {
 	return Version + "+" + Commit
 }


### PR DESCRIPTION
## Summary

Migrates `flake.nix` and `go/default.nix` from `amarbel-llc/gomod2nix` + pinned upstream nixpkgs to `amarbel-llc/nixpkgs`, which carries `buildGoApplication`, `mkGoEnv`, and the gomod2nix CLI natively.

Also refactors the Go buildinfo package to use `package main` vars so the fork's auto-injected `-X main.version` / `-X main.commit` ldflags are received correctly.

## Changes

### Go (Tasks 1–2)
- `go/internal/0/buildinfo`: added `Set(v, c string)` — variables stay in the `buildinfo` package but are now populated by each binary's `init()`
- `go/cmd/madder`, `go/cmd/madder-cache`, `go/cmd/madder-gen_man`: added `var version`/`var commit` + `func init() { buildinfo.Set(version, commit) }`
- Explicit `-ldflags` dropped from `buildGoApplication` — the fork injects `-X main.version`/`-X main.commit` automatically

### Nix (Tasks 3–4)
- `flake.nix`: switched `nixpkgs` input to `github:amarbel-llc/nixpkgs`, removed `gomod2nix` input and its `outputs` arg
- `go/default.nix`: removed gomod2nix overlay, `mkGoEnv` in devShell replaces explicit `go_1_26` + `gomod2nix.packages`
- `flake.lock`: regenerated

## Blocked

`nix build` fails because `buildGoApplication` can't find `go.mod` when `src = self` (repo root) and the Go module lives at `go/`. Tracking in **amarbel-llc/nixpkgs#6** — need to confirm the correct pattern for subdirectory Go modules.

The last commit (`wip: restore src = self`) marks the intended design; the fix will land once nixpkgs#6 is resolved.

---
🤡 [Clown](https://github.com/amarbel-llc/clown)