### PR TITLE
Optimize SFTP blob store with concurrent I/O and parallel walks

### DIFF
--- a/go/internal/foxtrot/blob_stores/store_remote_sftp.go
+++ b/go/internal/foxtrot/blob_stores/store_remote_sftp.go
@@ -9,8 +9,10 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
@@ -28,6 +30,25 @@ import (
 	"github.com/amarbel-llc/purse-first/libs/dewey/charlie/ohio"
 	"github.com/amarbel-llc/purse-first/libs/dewey/charlie/ui"
 )
+
+// sftpWriterBufferSize aligns the streaming-writer's bufio buffer with
+// pkg/sftp's default MaxPacket (32 KB). With UseConcurrentWrites enabled
+// the SFTP client pipelines packet-sized writes; sizing the upstream
+// bufio to match avoids fragmenting age's 64 KB chunks into the 4 KB
+// Go default.
+const sftpWriterBufferSize = 1 << 15 // 32 KiB
+
+// sftpKeepaliveInterval is the cadence at which initialize() sends
+// keepalive@openssh.com requests on the underlying ssh.Client so long
+// uploads or idle periods do not get torn down by servers (or NAT/
+// firewall stateful flows) that drop inactive connections.
+const sftpKeepaliveInterval = 30 * time.Second
+
+// sftpAllBlobsWorkerCount is the parallelism of the bucket-subtree walk
+// in allBlobsForBase. Each worker pulls a top-level bucket directory
+// from the task channel and walks it sequentially; the single shared
+// *sftp.Client pipelines RPCs over the one SSH channel.
+const sftpAllBlobsWorkerCount = 8
 
 type remoteSftp struct {
 	ctx       interfaces.ActiveContext
@@ -82,6 +103,14 @@ type remoteSftp struct {
 	// TODO extract below into separate struct
 	blobCacheLock sync.RWMutex
 	blobCache     map[string]struct{}
+
+	// dirsKnown remembers directories the store has already confirmed
+	// exist on the remote (either by creating them at init or by a
+	// successful MkdirAll during an upload). sftpMover.Close consults
+	// this to skip the per-write MkdirAll round trips on the deep
+	// bucket path that almost always already exists after the first
+	// blob lands in that bucket.
+	dirsKnown sync.Map
 }
 
 var _ domain_interfaces.BlobStore = &remoteSftp{}
@@ -265,10 +294,23 @@ func (blobStore *remoteSftp) initialize() (err error) {
 		return err
 	}
 
-	if blobStore.sftpClient, err = sftp.NewClient(blobStore.sshClient); err != nil {
+	// Enable pkg/sftp's pipelined reads and writes. Without these the
+	// client issues one MaxPacket-sized request per file at a time,
+	// which caps throughput at ~MaxPacket/RTT regardless of available
+	// bandwidth. The single *sftp.Client is goroutine-safe; concurrent
+	// requests multiplex over the one SSH channel. Keeping MaxPacket
+	// at the default (32 KB) preserves compatibility with SFTP servers
+	// that cap packet size to the protocol minimum.
+	if blobStore.sftpClient, err = sftp.NewClient(
+		blobStore.sshClient,
+		sftp.UseConcurrentReads(true),
+		sftp.UseConcurrentWrites(true),
+	); err != nil {
 		err = errors.Wrapf(err, "failed to create SFTP client")
 		return err
 	}
+
+	blobStore.startKeepalive()
 
 	blobStore.ctx.After(errors.MakeFuncContextFromFuncErr(blobStore.close))
 
@@ -301,6 +343,7 @@ func (blobStore *remoteSftp) initialize() (err error) {
 		blobStore.uiPrinter.Printf("checking directory %q...", currentPath)
 		_, err = blobStore.sftpClient.Stat(currentPath)
 		if err == nil {
+			blobStore.dirsKnown.Store(currentPath, struct{}{})
 			continue
 		}
 		if !errors.IsNotExist(err) {
@@ -323,9 +366,66 @@ func (blobStore *remoteSftp) initialize() (err error) {
 			}
 			err = nil
 		}
+		blobStore.dirsKnown.Store(currentPath, struct{}{})
 	}
 
 	return err
+}
+
+// startKeepalive pings the SSH server on a fixed cadence so a long
+// upload or idle gap does not get torn down by servers or stateful
+// network gear that drop quiet connections. The goroutine exits on
+// context completion or on the first SendRequest error (the connection
+// is dead at that point and close() will surface the actual error).
+func (blobStore *remoteSftp) startKeepalive() {
+	sshClient := blobStore.sshClient
+	if sshClient == nil {
+		return
+	}
+	done := blobStore.ctx.Done()
+	go func() {
+		ticker := time.NewTicker(sftpKeepaliveInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				if _, _, err := sshClient.SendRequest(
+					"keepalive@openssh.com", true, nil,
+				); err != nil {
+					return
+				}
+			}
+		}
+	}()
+}
+
+// ensureRemoteDir runs MkdirAll on dir unless the store has already
+// confirmed its existence in this process. On success it caches dir
+// and every parent prefix up to the store's remote root so subsequent
+// uploads to neighboring buckets skip the round trips.
+func (blobStore *remoteSftp) ensureRemoteDir(dir string) (err error) {
+	if _, ok := blobStore.dirsKnown.Load(dir); ok {
+		return nil
+	}
+	if err = blobStore.sftpClient.MkdirAll(dir); err != nil {
+		return err
+	}
+	rootPath := blobStore.config.GetRemotePath()
+	cur := dir
+	for cur != "" && cur != "." && cur != "/" {
+		blobStore.dirsKnown.Store(cur, struct{}{})
+		if cur == rootPath {
+			break
+		}
+		parent := path.Dir(cur)
+		if parent == cur {
+			break
+		}
+		cur = parent
+	}
+	return nil
 }
 
 func (blobStore *remoteSftp) GetBlobStoreDescription() string {
@@ -466,56 +566,200 @@ func shouldSkipBlobWalkEntry(name string) bool {
 // format-id segment — see allBlobsMultiHash. The walker yields paths
 // relative to the SFTP server root (no leading `/`), so we re-base
 // them via filepath.Rel before reconstructing the id.
+//
+// Implementation: ReadDir on basePath discovers the top-level bucket
+// directories; sftpAllBlobsWorkerCount workers walk those subtrees
+// concurrently (the single *sftp.Client is goroutine-safe and
+// pipelines RPCs over the one SSH channel). Yield order is preserved
+// per the BlobStore.AllBlobs contract — buckets are dispatched in
+// sorted order, each bucket's ids are sorted internally, and the
+// reader drains a per-bucket result channel in order so output is a
+// total lex-byte-order stream of MarklId.GetBytes() values. The
+// pre-pass single-thread Walk did not sort (pkg/sftp's server-side
+// Readdir returns entries in directory order, not alphabetical), so
+// this also closes that latent contract gap.
 func (blobStore *remoteSftp) allBlobsForBase(
 	basePath string,
 	hashType markl.FormatHash,
 ) interfaces.SeqError[domain_interfaces.MarklId] {
 	return func(yield func(domain_interfaces.MarklId, error) bool) {
-		walker := blobStore.sftpClient.Walk(basePath)
+		topEntries, err := blobStore.sftpClient.ReadDir(basePath)
+		if err != nil {
+			yield(nil, errors.Wrapf(err, "BasePath: %q", basePath))
+			return
+		}
 
-		digest, repool := hashType.GetBlobId()
-		defer repool()
+		bucketNames := make([]string, 0, len(topEntries))
+		for _, entry := range topEntries {
+			if !entry.IsDir() {
+				continue
+			}
+			if shouldSkipBlobWalkEntry(entry.Name()) {
+				continue
+			}
+			bucketNames = append(bucketNames, entry.Name())
+		}
+		sort.Strings(bucketNames)
 
-		for walker.Step() {
-			if err := walker.Err(); err != nil {
-				if !yield(nil, errors.Wrapf(err, "BasePath: %q", basePath)) {
+		if len(bucketNames) == 0 {
+			return
+		}
+
+		type bucketResult struct {
+			ids []domain_interfaces.MarklId
+			err error
+		}
+
+		// One result channel per bucket, buffered to 1 so the worker
+		// that finishes a bucket can hand off its slice and pick up
+		// the next task without waiting for the reader. The reader
+		// drains channels in order, which both preserves lex order
+		// and bounds in-flight memory to ~workerCount buckets.
+		results := make([]chan bucketResult, len(bucketNames))
+		for i := range results {
+			results[i] = make(chan bucketResult, 1)
+		}
+
+		tasks := make(chan int, len(bucketNames))
+		done := make(chan struct{})
+
+		workerCount := sftpAllBlobsWorkerCount
+		if workerCount > len(bucketNames) {
+			workerCount = len(bucketNames)
+		}
+
+		var wg sync.WaitGroup
+		for w := 0; w < workerCount; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				digest, repool := hashType.GetBlobId()
+				defer repool()
+				for idx := range tasks {
+					select {
+					case <-done:
+						return
+					default:
+					}
+					subPath := filepath.Join(basePath, bucketNames[idx])
+					ids, walkErr := walkBucketCollect(
+						blobStore.sftpClient,
+						subPath,
+						basePath,
+						digest,
+					)
+					select {
+					case results[idx] <- bucketResult{ids: ids, err: walkErr}:
+					case <-done:
+						return
+					}
+				}
+			}()
+		}
+
+		go func() {
+			defer close(tasks)
+			for i := range bucketNames {
+				select {
+				case tasks <- i:
+				case <-done:
 					return
 				}
-				continue
 			}
+		}()
 
-			if walker.Stat().IsDir() {
-				continue
+		closed := false
+		closeDone := func() {
+			if !closed {
+				closed = true
+				close(done)
 			}
-
-			if shouldSkipBlobWalkEntry(filepath.Base(walker.Path())) {
-				continue
-			}
-
-			relPath, err := filepath.Rel(basePath, walker.Path())
-			if err != nil {
-				if !yield(nil, errors.Wrapf(err, "BasePath: %q", basePath)) {
-					return
+		}
+		defer func() {
+			closeDone()
+			// Drain unread results so the buffered-1 sends in workers
+			// complete and the worker goroutines can return.
+			for i := range results {
+				select {
+				case <-results[i]:
+				default:
 				}
-				continue
 			}
+			wg.Wait()
+		}()
 
-			if err := markl.SetHexStringFromRelPath(digest, relPath); err != nil {
-				if !yield(nil, errors.Wrap(err)) {
-					return
-				}
-				continue
-			}
-
-			blobStore.blobCacheLock.Lock()
-			blobStore.blobCache[string(digest.GetBytes())] = struct{}{}
-			blobStore.blobCacheLock.Unlock()
-
-			if !yield(digest, nil) {
+		for i := range bucketNames {
+			var r bucketResult
+			select {
+			case r = <-results[i]:
+			case <-done:
 				return
+			}
+			if r.err != nil {
+				if !yield(nil, errors.Wrapf(
+					r.err, "BasePath: %q",
+					filepath.Join(basePath, bucketNames[i]),
+				)) {
+					closeDone()
+					return
+				}
+				continue
+			}
+			for _, id := range r.ids {
+				blobStore.blobCacheLock.Lock()
+				blobStore.blobCache[string(id.GetBytes())] = struct{}{}
+				blobStore.blobCacheLock.Unlock()
+				if !yield(id, nil) {
+					closeDone()
+					return
+				}
 			}
 		}
 	}
+}
+
+// walkBucketCollect walks subPath (one bucket subtree) and returns
+// every leaf reconstructed as a MarklId, sorted by raw bytes. Used by
+// the parallel allBlobsForBase fan-out; each worker calls this in
+// turn and posts the resulting slice to its bucket's result channel.
+// The digest is per-worker pooled; clones are emitted because callers
+// retain the ids past the next walk step.
+func walkBucketCollect(
+	client *sftp.Client,
+	subPath string,
+	basePath string,
+	digest domain_interfaces.MarklIdMutable,
+) (ids []domain_interfaces.MarklId, err error) {
+	walker := client.Walk(subPath)
+	for walker.Step() {
+		if stepErr := walker.Err(); stepErr != nil {
+			err = errors.Wrap(stepErr)
+			return ids, err
+		}
+		if walker.Stat().IsDir() {
+			continue
+		}
+		if shouldSkipBlobWalkEntry(filepath.Base(walker.Path())) {
+			continue
+		}
+		relPath, relErr := filepath.Rel(basePath, walker.Path())
+		if relErr != nil {
+			err = errors.Wrap(relErr)
+			return ids, err
+		}
+		if hexErr := markl.SetHexStringFromRelPath(
+			digest, relPath,
+		); hexErr != nil {
+			err = errors.Wrap(hexErr)
+			return ids, err
+		}
+		cloned, _ := markl.Clone(digest) //repool:owned
+		ids = append(ids, cloned)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return bytes.Compare(ids[i].GetBytes(), ids[j].GetBytes()) < 0
+	})
+	return ids, nil
 }
 
 func (blobStore *remoteSftp) MakeBlobWriter(
@@ -754,9 +998,12 @@ func (mover *sftpMover) Close() (err error) {
 	blobDigest := mover.writer.GetDigest()
 	finalPath := mover.store.remotePathForMerkleId(blobDigest)
 
-	// Ensure the target directory exists (Git-like bucketing)
+	// Ensure the target directory exists (Git-like bucketing). The
+	// store caches dirs it has already confirmed so repeat uploads to
+	// the same bucket — by far the common case once the tree is warm
+	// — skip the MkdirAll round trips entirely.
 	finalDir := path.Dir(finalPath)
-	if err = mover.store.sftpClient.MkdirAll(finalDir); err != nil {
+	if err = mover.store.ensureRemoteDir(finalDir); err != nil {
 		err = errors.Wrap(err)
 		return err
 	}
@@ -820,7 +1067,7 @@ func newSftpWriter(
 ) (writer *sftpWriter, err error) {
 	writer = &sftpWriter{}
 
-	writer.wBuf = bufio.NewWriter(ioWriter)
+	writer.wBuf = bufio.NewWriterSize(ioWriter, sftpWriterBufferSize)
 
 	if writer.wAge, err = config.GetBlobEncryption().WrapWriter(writer.wBuf); err != nil {
 		err = errors.Wrap(err)

--- a/go/internal/foxtrot/blob_stores/store_remote_sftp_bench_test.go
+++ b/go/internal/foxtrot/blob_stores/store_remote_sftp_bench_test.go
@@ -1,0 +1,558 @@
+//go:build test
+
+package blob_stores
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+
+	"github.com/amarbel-llc/madder/go/internal/alfa/blob_store_id"
+	"github.com/amarbel-llc/madder/go/internal/bravo/markl"
+	_ "github.com/amarbel-llc/madder/go/internal/bravo/plugins/builtins"
+	"github.com/amarbel-llc/purse-first/libs/dewey/0/interfaces"
+)
+
+// The benchmarks in this file target the specific knobs the SFTP-perf
+// pass tuned: pkg/sftp's UseConcurrentReads/UseConcurrentWrites, the
+// per-write MkdirAll cache, and the parallel bucket walk in
+// allBlobsForBase. They run an in-process pkg/sftp server over an
+// io.Pipe pair with optional per-packet latency injection, so each
+// benchmark can show the win over a high-RTT link without needing a
+// real network. The blob_io / hash / encryption layers are exercised
+// in zz-tests_bats/sftp.bats end to end and are not the point here.
+
+// benchLatency is the per-packet one-way "wire" delay the
+// latencyWriter injects. 5 ms is comfortably above Linux's time.Sleep
+// resolution (~1 ms) and gives a 10 ms nominal RTT — close enough to
+// a real LAN-over-VPN link to be meaningful while keeping each
+// benchmark iteration under a second. Round-trips per logical SFTP
+// op stay modest (Open + N data packets + Close), so the gap between
+// the sequential-default and the concurrent-options paths is clearly
+// visible without making the bench slow.
+const benchLatency = 5 * time.Millisecond
+
+// latencyWriter wraps an io.WriteCloser to simulate a high-RTT link
+// with proper pipelining. Each call to Write captures the packet
+// payload, spawns an independent timer goroutine, and queues the
+// packet for ordered delivery once the timer expires. Crucially the
+// Write returns immediately so the *sftp.Client (which serializes
+// outgoing packets behind a mutex) is unblocked to issue the next
+// packet right away — multiple in-flight timers overlap, which is
+// what enables UseConcurrentReads/Writes to show its win in a
+// loopback bench. Without per-packet goroutines a serial Sleep would
+// turn N pipelined requests into N * latency regardless of options.
+type latencyWriter struct {
+	dst     io.WriteCloser
+	latency time.Duration
+
+	queue  chan latencyPacket
+	closed chan struct{}
+}
+
+type latencyPacket struct {
+	data  []byte
+	ready chan struct{}
+}
+
+func newLatencyWriter(dst io.WriteCloser, latency time.Duration) *latencyWriter {
+	lw := &latencyWriter{
+		dst:     dst,
+		latency: latency,
+		queue:   make(chan latencyPacket, 1024),
+		closed:  make(chan struct{}),
+	}
+	go lw.deliver()
+	return lw
+}
+
+func (lw *latencyWriter) Write(p []byte) (int, error) {
+	data := append([]byte(nil), p...)
+	pkt := latencyPacket{data: data, ready: make(chan struct{})}
+	if lw.latency > 0 {
+		go func() {
+			time.Sleep(lw.latency)
+			close(pkt.ready)
+		}()
+	} else {
+		close(pkt.ready)
+	}
+	select {
+	case lw.queue <- pkt:
+	case <-lw.closed:
+		return 0, io.ErrClosedPipe
+	}
+	return len(p), nil
+}
+
+func (lw *latencyWriter) Close() error {
+	select {
+	case <-lw.closed:
+	default:
+		close(lw.closed)
+		close(lw.queue)
+	}
+	return nil
+}
+
+// deliver pops packets in FIFO order, waits for each packet's timer
+// to fire, then writes the payload to the destination pipe. Order is
+// preserved because the queue is FIFO; pipelining works because the
+// timers run concurrently — the Nth packet's release time is set as
+// soon as Write(N) returns, not after packet N-1 is delivered.
+func (lw *latencyWriter) deliver() {
+	for pkt := range lw.queue {
+		select {
+		case <-pkt.ready:
+		case <-lw.closed:
+			return
+		}
+		if _, err := lw.dst.Write(pkt.data); err != nil {
+			return
+		}
+	}
+	_ = lw.dst.Close()
+}
+
+// pipeRWC bundles an io.PipeReader and io.PipeWriter into the
+// io.ReadWriteCloser pkg/sftp's NewServer expects.
+type pipeRWC struct {
+	r io.Reader
+	w io.WriteCloser
+}
+
+func (p pipeRWC) Read(b []byte) (int, error)  { return p.r.Read(b) }
+func (p pipeRWC) Write(b []byte) (int, error) { return p.w.Write(b) }
+func (p pipeRWC) Close() error                { return p.w.Close() }
+
+// sftpBenchHarness holds an in-process sftp.Server and a connected
+// sftp.Client, plus a temp directory the server is allowed to touch.
+// The server runs in its own goroutine and shuts down when Close()
+// breaks the pipes.
+type sftpBenchHarness struct {
+	client     *sftp.Client
+	remotePath string
+	closers    []io.Closer
+}
+
+func (h *sftpBenchHarness) Close() {
+	for i := len(h.closers) - 1; i >= 0; i-- {
+		_ = h.closers[i].Close()
+	}
+}
+
+// newSFTPBenchHarness wires an in-process SFTP server to a client over
+// io.Pipe pairs. Each Write on either side is delayed by `latency` so
+// per-packet round trips approximate a 2*latency RTT link.
+//
+// The harness uses pkg/sftp's OS-backed NewServer, so the server reads
+// and writes files on the host filesystem. remotePath is a per-bench
+// t.TempDir() rooted under TMPDIR.
+func newSFTPBenchHarness(
+	tb testing.TB,
+	latency time.Duration,
+	clientOpts ...sftp.ClientOption,
+) *sftpBenchHarness {
+	tb.Helper()
+
+	remotePath := tb.TempDir()
+
+	c2sR, c2sW := io.Pipe()
+	s2cR, s2cW := io.Pipe()
+
+	var (
+		clientWrite io.WriteCloser = c2sW
+		serverWrite io.WriteCloser = s2cW
+	)
+	if latency > 0 {
+		clientWrite = newLatencyWriter(c2sW, latency)
+		serverWrite = newLatencyWriter(s2cW, latency)
+	}
+
+	serverRWC := pipeRWC{r: c2sR, w: serverWrite}
+	server, err := sftp.NewServer(serverRWC)
+	if err != nil {
+		tb.Fatalf("NewServer: %v", err)
+	}
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		_ = server.Serve()
+	}()
+
+	client, err := sftp.NewClientPipe(s2cR, clientWrite, clientOpts...)
+	if err != nil {
+		tb.Fatalf("NewClientPipe: %v", err)
+	}
+
+	h := &sftpBenchHarness{
+		client:     client,
+		remotePath: remotePath,
+	}
+	// Close in reverse order: client first (so the server sees EOF
+	// and returns), then pipe ends, then wait for the server goroutine.
+	h.closers = []io.Closer{
+		client,
+		c2sW, s2cW,
+		c2sR, s2cR,
+		closerFunc(func() error {
+			select {
+			case <-serverDone:
+			case <-time.After(2 * time.Second):
+			}
+			return nil
+		}),
+	}
+	return h
+}
+
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }
+
+// concurrentClientOptions mirrors the production initialize() path
+// after the perf pass: UseConcurrentReads(true) is a no-op against
+// pkg/sftp v1.13.10 defaults (disableConcurrentReads zeros to false,
+// so concurrent reads are already on) but is set anyway as
+// documentation of intent. UseConcurrentWrites(true) is the real
+// behavior change — pkg/sftp defaults it to false because concurrent
+// writes can leave holes on partial-failure paths, and we accept
+// that trade for the throughput win on long-RTT links.
+func concurrentClientOptions() []sftp.ClientOption {
+	return []sftp.ClientOption{
+		sftp.UseConcurrentReads(true),
+		sftp.UseConcurrentWrites(true),
+	}
+}
+
+// sequentialReadsOptions explicitly disables concurrent reads so the
+// GET benchmark can contrast "production concurrent" vs "old-school
+// sequential" download paths. The production initialize() path never
+// uses this; it exists only for the bench's A/B contrast.
+func sequentialReadsOptions() []sftp.ClientOption {
+	return []sftp.ClientOption{sftp.UseConcurrentReads(false)}
+}
+
+// writeBlobFile uploads a `size`-byte payload to remotePath/name via
+// the SFTP client and returns the duration. The payload is a single
+// allocation reused across iterations.
+func writeBlobFile(
+	tb testing.TB,
+	client *sftp.Client,
+	remoteFile string,
+	payload []byte,
+) {
+	tb.Helper()
+	f, err := client.Create(remoteFile)
+	if err != nil {
+		tb.Fatalf("Create(%q): %v", remoteFile, err)
+	}
+	if _, err := io.Copy(f, newRepeatReader(payload)); err != nil {
+		_ = f.Close()
+		tb.Fatalf("Copy to %q: %v", remoteFile, err)
+	}
+	if err := f.Close(); err != nil {
+		tb.Fatalf("Close(%q): %v", remoteFile, err)
+	}
+}
+
+// readBlobFile downloads remotePath/name to /dev/null via the SFTP
+// client.
+func readBlobFile(
+	tb testing.TB,
+	client *sftp.Client,
+	remoteFile string,
+) int64 {
+	tb.Helper()
+	f, err := client.Open(remoteFile)
+	if err != nil {
+		tb.Fatalf("Open(%q): %v", remoteFile, err)
+	}
+	defer f.Close()
+	n, err := io.Copy(io.Discard, f)
+	if err != nil {
+		tb.Fatalf("Copy from %q: %v", remoteFile, err)
+	}
+	return n
+}
+
+// newRepeatReader wraps a payload in an io.Reader that streams it
+// once and exhausts on EOF. It also implements Len() so pkg/sftp's
+// (*File).ReadFrom can detect the source size and engage the
+// concurrent-writes pipeline path; without Len/Size/Stat on the
+// source pkg/sftp silently falls back to sequential writes
+// regardless of UseConcurrentWrites — see client.go:2014-2092.
+func newRepeatReader(payload []byte) *repeatReader {
+	return &repeatReader{src: payload}
+}
+
+type repeatReader struct {
+	src []byte
+	pos int
+}
+
+func (r *repeatReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.src) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.src[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func (r *repeatReader) Len() int { return len(r.src) - r.pos }
+
+func benchBlobSizes(b *testing.B) []int {
+	b.Helper()
+	return []int{
+		64 * 1024,
+		1024 * 1024,
+	}
+}
+
+// BenchmarkSFTPPut contrasts pkg/sftp's sequential default
+// (UseConcurrentWrites=false) with the perf-pass setting
+// (UseConcurrentWrites=true). With the latencyWriter injecting 5 ms
+// per-packet RTT, the sequential path pays one RTT per MaxPacket-sized
+// chunk; the concurrent path pipelines them and pays roughly one RTT
+// for the whole transfer. The win grows with payload size.
+func BenchmarkSFTPPut(b *testing.B) {
+	for _, size := range benchBlobSizes(b) {
+		payload := make([]byte, size)
+		for i := range payload {
+			payload[i] = byte(i)
+		}
+
+		b.Run(fmt.Sprintf("Sequential/size=%d", size), func(b *testing.B) {
+			h := newSFTPBenchHarness(b, benchLatency)
+			defer h.Close()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				name := filepath.Join(
+					h.remotePath, fmt.Sprintf("blob_seq_%d", i),
+				)
+				writeBlobFile(b, h.client, name, payload)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Concurrent/size=%d", size), func(b *testing.B) {
+			h := newSFTPBenchHarness(
+				b, benchLatency, concurrentClientOptions()...,
+			)
+			defer h.Close()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				name := filepath.Join(
+					h.remotePath, fmt.Sprintf("blob_con_%d", i),
+				)
+				writeBlobFile(b, h.client, name, payload)
+			}
+		})
+	}
+}
+
+// BenchmarkSFTPGet contrasts pkg/sftp's concurrent-reads default
+// (the production path, also what
+// initialize() now sets explicitly) with the historically-sequential
+// fallback path callers hit on "read once" servers. For files larger
+// than MaxPacket the concurrent path issues N read requests up to
+// maxConcurrentRequests at a time; the sequential path issues one
+// and waits.
+func BenchmarkSFTPGet(b *testing.B) {
+	for _, size := range benchBlobSizes(b) {
+		payload := make([]byte, size)
+		for i := range payload {
+			payload[i] = byte(i)
+		}
+
+		b.Run(fmt.Sprintf("Sequential/size=%d", size), func(b *testing.B) {
+			h := newSFTPBenchHarness(
+				b, benchLatency, sequentialReadsOptions()...,
+			)
+			defer h.Close()
+			remoteFile := filepath.Join(h.remotePath, "blob")
+			writeBlobFile(b, h.client, remoteFile, payload)
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				readBlobFile(b, h.client, remoteFile)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Concurrent/size=%d", size), func(b *testing.B) {
+			h := newSFTPBenchHarness(
+				b, benchLatency, concurrentClientOptions()...,
+			)
+			defer h.Close()
+			remoteFile := filepath.Join(h.remotePath, "blob")
+			writeBlobFile(b, h.client, remoteFile, payload)
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				readBlobFile(b, h.client, remoteFile)
+			}
+		})
+	}
+}
+
+// populateBuckets seeds remotePath with a hash-bucketed tree of
+// 1-byte placeholder files so AllBlobs has a realistic shape to
+// walk. Returns the number of leaf files created.
+func populateBuckets(tb testing.TB, client *sftp.Client, remotePath string) int {
+	tb.Helper()
+	// 16 top-level bucket dirs; 8 leaf files each = 128 blobs. With
+	// buckets=[2] each leaf name is the rest of a sha256 digest hex
+	// after the 2-char bucket prefix (62 hex chars). The walker only
+	// checks shouldSkipBlobWalkEntry / IsDir; the actual byte content
+	// of leaves doesn't matter for the walk benchmark.
+	const topBuckets = 16
+	const leavesPerBucket = 8
+	leafSuffix := "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	for i := 0; i < topBuckets; i++ {
+		bucket := fmt.Sprintf("%02x", i)
+		dir := filepath.Join(remotePath, bucket)
+		if err := client.Mkdir(dir); err != nil && !os.IsExist(err) {
+			tb.Fatalf("Mkdir(%q): %v", dir, err)
+		}
+		for j := 0; j < leavesPerBucket; j++ {
+			leaf := filepath.Join(
+				dir,
+				fmt.Sprintf("%s%02x", leafSuffix[:len(leafSuffix)-2], j),
+			)
+			f, err := client.Create(leaf)
+			if err != nil {
+				tb.Fatalf("Create(%q): %v", leaf, err)
+			}
+			_ = f.Close()
+		}
+	}
+	return topBuckets * leavesPerBucket
+}
+
+// BenchmarkSFTPAllBlobsWalk_Sequential runs the pre-pass behavior:
+// a single goroutine calling sftpClient.Walk on the store root.
+func BenchmarkSFTPAllBlobsWalk_Sequential(b *testing.B) {
+	h := newSFTPBenchHarness(b, benchLatency, concurrentClientOptions()...)
+	defer h.Close()
+	populateBuckets(b, h.client, h.remotePath)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		walker := h.client.Walk(h.remotePath)
+		for walker.Step() {
+			if err := walker.Err(); err != nil {
+				b.Fatalf("walker: %v", err)
+			}
+			if walker.Stat().IsDir() {
+				continue
+			}
+			if shouldSkipBlobWalkEntry(filepath.Base(walker.Path())) {
+				continue
+			}
+		}
+	}
+}
+
+// BenchmarkSFTPAllBlobsWalk_Parallel runs the post-pass behavior:
+// allBlobsForBase fans out across sftpAllBlobsWorkerCount workers.
+// Uses a benchmark-only remoteSftp shell with the field set the
+// parallel walk needs and the once gate latched so initialize() is
+// skipped.
+func BenchmarkSFTPAllBlobsWalk_Parallel(b *testing.B) {
+	h := newSFTPBenchHarness(b, benchLatency, concurrentClientOptions()...)
+	defer h.Close()
+	populateBuckets(b, h.client, h.remotePath)
+
+	store := newBenchStore(b, h.client, h.remotePath)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		for _, err := range store.allBlobsForBase(
+			h.remotePath,
+			markl.FormatHashSha256,
+		) {
+			if err != nil {
+				b.Fatalf("allBlobsForBase: %v", err)
+			}
+			count++
+		}
+		if count == 0 {
+			b.Fatalf("walk yielded zero blobs")
+		}
+	}
+}
+
+// newBenchStore builds a remoteSftp wired to the benchmark's client.
+// It latches once.Do with a no-op so initialize() (which needs an
+// ssh.Client and a blob_store-config) never runs and the bench can
+// call the post-init code paths directly.
+func newBenchStore(
+	tb testing.TB,
+	client *sftp.Client,
+	remotePath string,
+) *remoteSftp {
+	tb.Helper()
+	var id blob_store_id.Id
+	if err := id.Set("sftp-bench"); err != nil {
+		tb.Fatalf("blob_store_id.Set: %v", err)
+	}
+	store := &remoteSftp{
+		ctx:             benchContext{},
+		id:              id,
+		config:          benchRemotePathConfig{remotePath: remotePath},
+		buckets:         defaultBuckets,
+		defaultHashType: markl.FormatHashSha256,
+		blobCache:       map[string]struct{}{},
+		sftpClient:      client,
+	}
+	store.once.Do(func() {}) // latch: initialize() will not run
+	return store
+}
+
+// benchRemotePathConfig is the minimal ConfigSFTPRemotePath
+// implementation the store needs for GetRemotePath lookups. Other
+// blob_store_configs.Config methods are unreachable in the bench
+// paths (we don't call GetBlobStoreConfig or marshal).
+type benchRemotePathConfig struct {
+	remotePath string
+}
+
+func (c benchRemotePathConfig) GetRemotePath() string     { return c.remotePath }
+func (c benchRemotePathConfig) GetKnownHostsFile() string { return "" }
+
+// GetBlobStoreType satisfies domain_interfaces.BlobStoreConfig. The
+// bench paths never serialize the config, but the production
+// remoteSftp struct's `config` field is typed
+// blob_store_configs.ConfigSFTPRemotePath which embeds
+// BlobStoreConfig, so the method must exist for the struct literal
+// to compile.
+func (c benchRemotePathConfig) GetBlobStoreType() string { return "sftp-bench" }
+
+// benchContext is a no-op interfaces.ActiveContext used by the bench
+// store. The bench paths never trigger Cancel/After/Must.
+type benchContext struct{}
+
+func (benchContext) Deadline() (time.Time, bool)          { return time.Time{}, false }
+func (benchContext) Done() <-chan struct{}                { return nil }
+func (benchContext) Err() error                           { return nil }
+func (benchContext) Value(_ any) any                      { return nil }
+func (benchContext) Cause() error                         { return nil }
+func (benchContext) GetState() interfaces.ContextState    { return interfaces.ContextStateStarted }
+func (benchContext) Cancel(_ error)                       {}
+func (benchContext) After(_ interfaces.FuncActiveContext) {}
+func (benchContext) Must(_ interfaces.FuncActiveContext)  {}
+
+var (
+	_ context.Context          = benchContext{}
+	_ interfaces.ActiveContext = benchContext{}
+)

--- a/go/internal/foxtrot/blob_stores/util_ssh.go
+++ b/go/internal/foxtrot/blob_stores/util_ssh.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/amarbel-llc/madder/go/internal/delta/blob_store_configs"
 	"github.com/amarbel-llc/purse-first/libs/dewey/0/interfaces"
@@ -16,6 +17,12 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
 )
+
+// defaultSSHDialTimeout bounds ssh.Dial when ssh.ClientConfig.Timeout is
+// otherwise unset, so a wedged remote does not block CLI commands
+// indefinitely. ssh.Dial honors ClientConfig.Timeout via its default
+// net.Dialer.
+const defaultSSHDialTimeout = 30 * time.Second
 
 // sshConfigResolution holds the subset of ssh_config fields we care
 // about. Fields are populated by resolveSSHConfig from `ssh -G`
@@ -356,6 +363,10 @@ func sshDial(
 	configClient *ssh.ClientConfig,
 	addr string,
 ) (sshClient *ssh.Client, err error) {
+	if configClient.Timeout == 0 {
+		configClient.Timeout = defaultSSHDialTimeout
+	}
+
 	uiPrinter.Printf("dialing %q...", addr)
 	if sshClient, err = ssh.Dial("tcp", addr, configClient); err != nil {
 		err = errors.Wrapf(err, "failed to connect to SSH server")


### PR DESCRIPTION
## Summary

This change optimizes the remote SFTP blob store for high-latency links by enabling concurrent reads/writes in the pkg/sftp client, implementing a directory existence cache to eliminate redundant MkdirAll calls, parallelizing the blob discovery walk across worker goroutines, and adding SSH keepalive to prevent connection timeouts during long operations.

## Key Changes

- **Concurrent SFTP I/O**: Enable `UseConcurrentReads` and `UseConcurrentWrites` in the sftp.Client to pipeline packet-sized requests over the single SSH channel, dramatically improving throughput on high-RTT links. Align the streaming writer's bufio buffer (32 KiB) with pkg/sftp's MaxPacket size to avoid fragmenting upstream chunks.

- **Directory existence cache**: Add `dirsKnown` sync.Map to track directories confirmed to exist, eliminating redundant MkdirAll round trips when uploading multiple blobs to the same bucket. The cache is populated during initialization and on successful MkdirAll calls, with parent directories cached up to the remote root.

- **Parallel blob discovery**: Replace the single-threaded `Walk` in `allBlobsForBase` with a fan-out pattern: ReadDir discovers top-level buckets, then `sftpAllBlobsWorkerCount` (8) workers walk bucket subtrees concurrently. Results are collected per-bucket, sorted, and yielded in lex-byte order to preserve the BlobStore.AllBlobs contract. This also closes a latent contract gap by sorting output (the pre-pass Walk did not).

- **SSH keepalive**: Add `startKeepalive()` to send `keepalive@openssh.com` requests every 30 seconds on the underlying ssh.Client, preventing connection teardown by idle-sensitive servers or stateful network gear during long uploads or idle periods.

- **SSH dial timeout**: Add a 30-second default timeout to ssh.Dial when ClientConfig.Timeout is unset, preventing indefinite hangs on wedged remotes.

- **Comprehensive benchmarks**: Add `store_remote_sftp_bench_test.go` with in-process SFTP server benchmarks over io.Pipe pairs with optional per-packet latency injection (5 ms nominal RTT). Benchmarks cover:
  - `BenchmarkSFTPPut`: Sequential vs. concurrent writes (64 KB and 1 MB payloads)
  - `BenchmarkSFTPGet`: Sequential vs. concurrent reads (64 KB and 1 MB payloads)
  - `BenchmarkSFTPAllBlobsWalk_Sequential` and `BenchmarkSFTPAllBlobsWalk_Parallel`: Single-threaded vs. parallel bucket walks

## Implementation Details

- The `latencyWriter` helper injects per-packet delays with independent timer goroutines so the SFTP client (which serializes outgoing packets behind a mutex) can pipeline requests—multiple in-flight timers overlap, enabling concurrent options to show measurable wins in loopback benchmarks without needing a real network.

- The parallel walk uses a task channel to distribute bucket indices to workers, per-bucket result channels (buffered to 1) to preserve lex order and bound in-flight memory, and a shared WaitGroup to coordinate shutdown. The reader drains result channels in order, ensuring output is a total lex-byte-order stream of MarklId.GetBytes() values.

- `walkBucketCollect` is extracted as a helper to walk a single bucket subtree and return sorted ids, allowing workers to pool a single digest across multiple buckets.

- The benchmark harness includes minimal mock implementations (`benchRemotePathConfig`, `benchContext`) to allow direct testing of post-initialization code paths without requiring an ssh.Client or blob_store-config.

https://claude.ai/code/session_01K1fnSXCeKh9zR9m6E3onyP