### PR TITLE
docs: FDR-0008 (config digest pins) + Phase 1 implementation plan

### DIFF
--- a/docs/features/0008-config-digest-pins.md
+++ b/docs/features/0008-config-digest-pins.md
@@ -1,0 +1,467 @@
+---
+status: proposed
+date: 2026-05-17
+promotion-criteria: |
+  Promote to `experimental` once Phase 1 (config self-check) lands and
+  the bats suite covering the new `madder config-pin_digest` command
+  and the `madder list` migration footer passes. Promote to `accepted`
+  after Phase 2 (digest suffix on blob-store-ids) lands behind the
+  same test bar and at least one persisted-reference call site (e.g.
+  cutting-garden capture receipts) opts into emitting the
+  digest-bearing form.
+---
+
+# Config Digest Pins
+
+## Problem Statement
+
+A blob-store-id today is a name + location prefix
+(`go/internal/alfa/blob_store_id/main.go`). Two stores named `default`
+on different machines, or two `default` stores that drift after a
+manual `blob_store-config` edit, are indistinguishable by their ID.
+References to blob stores in receipts and configs are therefore
+untrustworthy across hosts and tamper-blind against local edits.
+
+The `blob_store-config` file itself has no integrity check. A user
+editing the config — to flip `verify-on-collision`, to change
+compression, or maliciously — leaves no in-band evidence. The file is
+trusted by every read path on the basis of "it parsed".
+
+This FDR closes both gaps in two phases:
+
+1. **Phase 1 (self-check).** Every `blob_store-config` carries an
+   `@ <markl-id>` line in its hyphence metadata. The digest covers the
+   config's body bytes. Read paths recompute and assert; mismatch is
+   a hard failure with both digests in the error.
+2. **Phase 2 (digest suffix on IDs).** `blob_store_id.Id` accepts an
+   optional digest suffix:
+   `default@blake2b256-9ft3m74l5t2ppwjrvfg3wp380jqj2zfrm6zevxqx34sdethvey0s5vm9gd`.
+   At resolve time, the suffix is `AssertEqual`'d against the
+   config's Phase 1 digest. Two stores sharing a name across hosts
+   are now distinguishable by their digest; persisted references can
+   pin a store cryptographically without giving up the friendly hint.
+
+The mechanism for Phase 1 already exists: hyphence's typed-metadata
+coder writes and reads `@ <markl-id>` lines today
+(`go/internal/charlie/hyphence/coder_metadata.go:26`). The
+expected-vs-actual error type already exists too: `markl.ErrNotEqual`
+at `go/internal/bravo/markl/errors.go:167`. Phase 1 wires the
+existing pieces together for `blob_store-config`; Phase 2 extends the
+ID's text form to carry the digest.
+
+This FDR originates from issue #194.
+
+## Interface
+
+### Phase 1: Config Self-Check
+
+**Wire format.** A migrated `blob_store-config` carries an `@` line
+in its hyphence metadata section:
+
+    !toml-blob_store_config-v0
+    @ madder-blob_store-config-digest-v1@blake2b256-9ft3m74l5t2ppwjrvfg3wp380jqj2zfrm6zevxqx34sdethvey0s5vm9gd
+
+The digest covers the **body bytes** that follow the closing hyphence
+boundary — i.e. the config payload that `coder.Blob.EncodeTo`
+serializes. The metadata section (the `!` line, the `@` line itself,
+both `Boundary` markers, and the blank separator) is **not** in the
+hash input. This matches the natural seam in
+`hyphence.CoderToTypedBlob` (`coder_to_typed_blob.go:133-181`) and
+keeps the self-reference well-defined.
+
+**Hash family.** `blake2b256`, hard-coded. madder's preferred hash;
+the only alternative (`sha256`) does not justify a configuration knob
+for self-check in Phase 1.
+
+**Markl purpose.** A new purpose registered in
+`go/internal/bravo/markl/purposes.go`:
+
+    madder-blob_store-config-digest-v1
+
+This is a madder-native artifact, not a dodder wire-format string. It
+does **not** belong in the locked-strings bucket tracked by #16.
+
+**Write path.** Every code path that emits a fresh
+`blob_store-config` populates the `@` line unconditionally:
+
+- `madder init`
+- `madder init-sftp-explicit`, `madder init-sftp-ssh_config`
+- `madder init-webdav`
+- `madder init-s3`
+- `madder init-pointer`, `madder init-pointer-v0`
+- `madder init-from`
+- `madder init-inventory-archive`
+
+The mechanism: the config encoder renders the body to an in-memory
+buffer, computes the digest, sets `TypedBlob.BlobDigest`, then writes
+metadata + body via the existing hyphence coder. The metadata writer
+already emits a non-null `BlobDigest` as `@ <markl-id>`
+(`coder_metadata.go:56-67`).
+
+**Read path.** Three cases:
+
+1. **`@` line present.** Recompute body digest, call
+   `markl.AssertEqual(stored, computed)`. Mismatch returns
+   `markl.ErrNotEqual` carrying `Expected` and `Actual`. The CLI
+   rendering shows both digests on separate lines so the user can
+   see exactly what drifted.
+2. **`@` line absent (legacy config).** Trusted silently. Behavior
+   identical to today. This is the back-compat seam: an upgraded
+   madder does not break on first read of any existing on-disk
+   config.
+3. **`@` line present but malformed.** Hard parse error. A
+   syntactically broken markl-id is a corruption signal, not a
+   "legacy" condition.
+
+**Body-byte capture during decode.** The body of a hyphence-wrapped
+config is read into the typed blob, but the raw bytes are needed for
+re-hashing. A thin wrapping reader tees the post-second-boundary
+bytes into a `blake2b256` hasher; the hash is finalized when the
+typed-blob decoder returns. This is added inside the
+blob_store-config decode call site, not in the generic hyphence
+coder.
+
+### Migration Command: `madder config-pin_digest`
+
+Mints the `@` line on a config that lacks one. Idempotent: a config
+that already has an `@` line is decoded (which triggers the Phase 1
+self-check) and re-emitted; on a matching digest the rewrite is a
+byte-identical no-op.
+
+**Synopsis.**
+
+    madder config-pin_digest <blob-store-id> [<blob-store-id> ...]
+    madder config-pin_digest --all
+
+`<blob-store-id>` accepts the same forms as every other CLI surface
+that takes one. `--all` walks every configured store under the
+active XDG roots; the two modes are mutually exclusive.
+
+**Exit codes.**
+
+- `0` — every targeted config now carries a valid `@` line.
+- nonzero — at least one config failed the Phase 1 self-check on
+  decode. A mismatched config is exactly what migration must
+  surface; silent re-mint of a tampered config would defeat the
+  purpose of the digest.
+
+### `madder list`: Migration Surface
+
+`madder list` is the primary discovery path for both the migration
+state and the digest-bearing IDs themselves.
+
+**Text output.** Each row's ID column emits the canonical text form
+including `@<digest>` for migrated stores. Unmigrated stores render
+as the bare name with a `(unmigrated)` marker in the same column.
+
+When at least one unmigrated store is in the listing, a footer at
+the end of the output prints a copy-pasteable command listing
+exactly those store IDs:
+
+    NOTE: 3 store(s) above are missing tamper-detection digests.
+          Run this to migrate them:
+
+            madder config-pin_digest default .archive %scratch
+
+The footer is omitted when every listed store is already migrated.
+The footer wording matches the copy-pasteable-command pattern used
+by the legacy-rename error (#175). The migration-discovery UX is
+in the same spirit as the broader UX umbrella tracked by #174.
+
+**ndjson / json output.** `madder list` already supports
+`-format=ndjson` and `-format=json`, with ndjson auto-selected when
+stdout is piped (`go/internal/india/commands/list.go:41-49`). Both
+gain two fields:
+
+- `digest`: the markl-id string for migrated stores (omitted for
+  unmigrated).
+- `digest_missing`: `true` for unmigrated stores (omitted for
+  migrated).
+
+No new format flag is introduced.
+
+### Phase 2: Digest Suffix on Blob-Store-IDs
+
+**Text form.**
+
+    blob-store-id = [prefix] name [ "@" markl-id ]
+    prefix        = "." | ".." | "..." | ... | "/" | "%" | "_" | "~"
+    name          = [a-zA-Z0-9_-]+
+    markl-id      = format "-" blech32-data
+
+Examples:
+
+- `default` — bare (unchanged).
+- `default@blake2b256-9ft3m74l...` — XDG user, with digest.
+- `.archive@blake2b256-...` — CWD-relative, with digest.
+- `%scratch@blake2b256-...` — XDG cache, with digest.
+
+**Parser (`Id.Set`).** Split on the **first** `@`. The left side
+flows through the existing prefix/name parser unchanged. The right
+side parses via `markl.Id.Set`; an invalid markl-id is a hard parse
+error, not a silent drop. The name charset is unchanged
+(`[a-zA-Z0-9_-]`) so `@` is unambiguously the digest separator.
+
+**Canonical form (`Id.Canonical`).** Emits `[prefix]name[@digest]`.
+The cwdDepth flattening rule from #145 (single-dot for Cwd) is
+unchanged. The digest, when present, round-trips byte-identical.
+
+**Struct.**
+
+    type Id struct {
+        location xdg_location_type.Typee
+        id       string
+        cwdDepth uint
+        digest   markl.Id  // zero-value = no digest
+    }
+
+New accessors: `GetDigest() markl.Id`, `HasDigest() bool`,
+`WithDigest(markl.Id) Id`.
+
+**`Less` ordering.** Compares by location, then `id`, then
+`cwdDepth`, then digest (via `markl.Compare`). Two IDs differing
+only in their digest sort deterministically — codified by a hard
+invariant test.
+
+**Resolution.** When a CLI arg parses to an `Id` with
+`HasDigest() == true`:
+
+1. Locate the on-disk config exactly as today (prefix + name).
+2. Decode it through the Phase 1 path. The config is either
+   migrated (self-check runs) or legacy (trusted silently).
+3. If the config has its own digest, `markl.AssertEqual` between
+   the ID's digest and the config's digest. Mismatch returns
+   `markl.ErrNotEqual` with both digests.
+4. If the config is legacy (no `@` line) but the ID supplies a
+   digest, return a dedicated typed error:
+
+       blob-store-id supplied a digest but the store's config is
+       unmigrated. Run `madder config-pin_digest <id>` to mint a
+       digest, then retry.
+
+   Silently trusting an ID's digest against an un-digestable config
+   defeats the point of the suffix.
+
+**Emission.** Phase 2 does **not** rewrite any existing on-disk
+reference. Receipts, configs, and inventory archive entries stay
+byte-identical on disk. Phase 2 only governs how `Id.Canonical()`
+renders when the in-memory value happens to carry a digest. Future
+call sites that want to *start* persisting digest-bearing IDs (e.g.
+cutting-garden capture receipts) opt in deliberately at the call
+site; this FDR does not sweep that change.
+
+**Code touchpoints.**
+
+- `go/internal/alfa/blob_store_id/main.go` — `Id` struct gains
+  `digest`; `Set` / `String` / `Canonical` / `Less` / `MarshalText`
+  / `UnmarshalText` updated.
+- `go/internal/foxtrot/blob_store_env/main.go` — resolver path
+  that turns an `Id` into a live store; new `AssertEqual` at the
+  seam.
+- `go/internal/golf/command_components/blob_store.go` — CLI flag
+  parsing path; inherits the new shape through `Id.Set`.
+- New error type for "digest supplied against unmigrated config",
+  alongside `blob_store_id`.
+
+**Inline-store-switching.** Several commands (`write`, `pack-blobs`,
+`cat`, `has`) accept positional arguments that may be either data
+arguments (file paths, markl IDs) or blob-store-ids. An arg of the
+form `[a-zA-Z0-9_-]+@<markl-id>` is unambiguously a blob-store-id —
+distinct from a bare markl-id (no leading name + `@`) and from a
+filename (`./` or explicit prefix disambiguates). No precedence
+change is required. Filenames containing literal `@` characters
+must be disambiguated by an explicit `./` prefix, the same
+convention used today for store IDs that look like filenames.
+
+## Examples
+
+### Phase 1: self-check catches tampering
+
+    $ madder list
+    default     blake2b256-9ft3m74l...    /home/sf/.local/share/madder/...
+    $ vim ~/.local/share/madder/blob_stores/default/blob_store-config
+    # ...edit one byte in the body...
+    $ madder list
+    error: blob_store-config digest mismatch for "default"
+      expected: blake2b256-9ft3m74l...
+      actual:   blake2b256-2k4p9r3m...
+
+### Migrating an existing store
+
+    $ madder list
+    default      (unmigrated)    /home/sf/.local/share/madder/...
+    .archive     (unmigrated)    /home/sf/proj/.madder/...
+
+    NOTE: 2 store(s) above are missing tamper-detection digests.
+          Run this to migrate them:
+
+            madder config-pin_digest default .archive
+
+    $ madder config-pin_digest default .archive
+    $ madder list
+    default@blake2b256-9ft3m74l...   /home/sf/.local/share/madder/...
+    .archive@blake2b256-7q3w5h2x...  /home/sf/proj/.madder/...
+
+### Phase 2: digest-bearing ID resolves cleanly
+
+    $ madder cat -store 'default@blake2b256-9ft3m74l...' blake2b256-abc...
+    <blob content>
+
+### Phase 2: digest mismatch refuses
+
+    $ madder cat -store 'default@blake2b256-WRONG...' blake2b256-abc...
+    error: blob-store-id digest does not match resolved store
+      expected: blake2b256-WRONG...
+      actual:   blake2b256-9ft3m74l...
+
+### Phase 2: digest supplied against legacy config refuses
+
+    $ madder cat -store 'default@blake2b256-9ft3m74l...' blake2b256-abc...
+    error: blob-store-id supplied a digest but the store's config
+    is unmigrated.
+    hint: run `madder config-pin_digest default` to mint a digest,
+          then retry
+
+## Testing
+
+**Phase 1 — round-trip & tamper.**
+
+- Round-trip: encode a config, decode, assert the `@` line
+  round-trips byte-identical.
+- Tamper: encode a config, mutate one body byte on disk, decode →
+  expect `markl.ErrNotEqual` with both digests in the message.
+- Legacy passthrough: hand-write a config without an `@` line,
+  decode → expect success, no error.
+- Malformed `@`: hand-write an `@` line with a bogus markl-id
+  payload → expect hard parse error.
+
+**Phase 1 — init coverage.** One bats integration test per `init-*`
+command asserting the emitted `blob_store-config` contains an `@`
+line.
+
+**`madder config-pin_digest`.**
+
+- Round-trip on a legacy config; re-run → second invocation is a
+  byte-identical no-op.
+- `--all` walks every configured store under the active XDG roots.
+- A tampered config under `--all` causes a nonzero exit and is
+  reported by ID.
+
+**Phase 2 — parser.** Table-test in `blob_store_id`: bare `name`,
+`name@blake2b256-...`, and every prefix (`.`, `..`, `/`, `%`, `_`,
+`~`) crossed with `{with, without}` digest. Round-trip each through
+`MarshalText` / `UnmarshalText`.
+
+**Phase 2 — `Less` invariant (HARD REQUIREMENT).** Two IDs differing
+only in their digest sort deterministically. Map/set callers depend
+on this.
+
+**Phase 2 — resolution.**
+
+- Digest mismatch: config with digest X, ID with digest Y → expect
+  `markl.ErrNotEqual`.
+- Digest against legacy config: legacy config + ID with digest →
+  expect the dedicated error pointing at `config-pin_digest`.
+
+**`madder list`.**
+
+- Mixed-state fixture (some migrated, some not): text output shows
+  the digest-bearing form for migrated stores and `(unmigrated)`
+  for legacy; footer lists exactly the unmigrated IDs.
+- ndjson/json modes: migrated rows carry `digest`; legacy rows
+  carry `digest_missing: true`.
+- All-migrated fixture: no footer.
+
+## Risks
+
+- **Existing on-disk references break.** Mitigation: Phase 2 doesn't
+  rewrite any persisted ID. The wire format is strictly additive
+  (digestless forms keep working). Legacy configs (no `@` line) are
+  trusted silently on read.
+- **Filenames containing `@` misparse as digest-bearing IDs.**
+  Mitigation: same disambiguation convention as today's
+  name-vs-filename collisions — `./foo@bar` is a file, `foo@bar` is
+  a store ID. To be called out in `blob-store(7)`.
+- **Migration footer fatigue.** A user who runs `madder list`
+  repeatedly without migrating sees the footer every time. This is
+  acceptable noise — suppressing it would hide the upgrade signal.
+  The footer disappears once stores are migrated.
+- **`madder list` text output gets wide.** A `blake2b256` digest is
+  ~70 chars including the `blake2b256-` prefix. An 80-col terminal
+  is tight. A `--short` / `--no-digest` escape hatch is captured in
+  Future Work; not blocking for the FDR.
+- **Tamper detection misread as covering blob contents.** Mitigation:
+  the FDR and `blob-store(7)` explicitly state the digest covers the
+  config only.
+- **Legitimate config edits trigger digest mismatch.** This is by
+  design. The user re-mints via `madder config-pin_digest`,
+  acknowledging the change explicitly.
+
+## Rollback
+
+- **Phase 2 first, Phase 1 second.** Revert order matters: roll
+  back Phase 2's resolve-time `AssertEqual` (the new failure mode
+  on digest-bearing IDs) before touching Phase 1. Phase 2 is opt-in
+  — only users who type or persist a digest-bearing ID see the new
+  failure — so the blast radius is bounded by adoption.
+- **Phase 1's read-side `AssertEqual` is the unit.** Revert that
+  one call site to remove the digest-mismatch failure mode entirely.
+  The `@` lines remain on disk and are harmless.
+- **The `digest` field on `Id` is harmless to leave compiled in.**
+  Zero-value means "no digest"; rolling back the parser to ignore
+  `@` is sufficient if a wire-format-side rollback is ever needed.
+- **No feature flag.** Both phases ship without an env-var or
+  config gate. Phase 1's per-call-site revert is small enough that
+  gating it would add complexity without measurable safety upside.
+  Phase 2 is naturally opt-in by user action.
+- **Pre-Phase-1 binary compatibility is out of scope.** A user who
+  downgrades madder after migrating configs is responsible for
+  re-testing; this FDR makes no claim about reverse-version reads.
+
+## Future Work
+
+Each item gets its own explore issue.
+
+- **Absolute-path location type for blob-store-ids.** Resolves the
+  `.foo` vs `..foo` relative-form ambiguity by allowing a store to
+  be addressed by absolute path in the ID itself. Likely warrants
+  its own RFC because it changes the wire format, the parser, and
+  the interaction with `cwdDepth` (see #145, #153, #156). The Phase
+  2 ID parser leaves room: the `name` slot stays opaque to the
+  digest mechanism, so a future location type fits without
+  disturbing digest semantics.
+- **Pinning persisted references.** Call sites that emit
+  blob-store-ids into receipts, configs, and inventory archives can
+  opt in to emitting the digest-bearing form. Per-call-site design.
+  cutting-garden capture receipts are the natural first candidate.
+- **`madder list --short` / `--no-digest` flag.** Narrow-terminal
+  escape hatch. The default stays full-digest (per this FDR).
+- **`madder fsck` integration.** `fsck` could surface unmigrated
+  stores the same way `list` does, with the same copy-pasteable
+  command. Ties into #174.
+- **sha256-only stores.** Phase 1 hard-codes `blake2b256` as the
+  self-check hash. Revisit if a sha256-only store needs self-check.
+
+## More Information
+
+- **Origin:** #194 ("Explore: extend blob-store IDs with content
+  blake-digest as markl-id (hint + hard pin)").
+- **Locked wire-format strings (#16):** the new
+  `madder-blob_store-config-digest-v1` purpose is madder-native and
+  is **not** in the dodder-wire-format bucket. No coordination
+  required.
+- **UX umbrella (#174):** the `madder list` migration footer is in
+  the same spirit as the `init` / `sync` / `fsck` / `pack` UX
+  improvements tracked there.
+- **Copy-pasteable-command pattern (#175):** the legacy-rename
+  error establishes the footer pattern this FDR adopts.
+- **Relative-path ambiguity (#145, #153, #156):** related to the
+  deferred absolute-path-location future work, but explicitly out
+  of scope here.
+- **Hyphence metadata mechanism:**
+  `go/internal/charlie/hyphence/coder_metadata.go:21-71` —
+  Phase 1 reuses the existing `@ <markl-id>` line-writer and
+  `BlobDigest` typed-blob field.
+- **Expected-vs-actual error type:**
+  `go/internal/bravo/markl/errors.go:167-203` —
+  `markl.ErrNotEqual` + `markl.AssertEqual`. Used by both phases.

--- a/docs/plans/2026-05-17-config-digest-pins-phase1.md
+++ b/docs/plans/2026-05-17-config-digest-pins-phase1.md
@@ -1,0 +1,1449 @@
+# Config Digest Pins — Phase 1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use eng:subagent-driven-development
+> to implement this plan task-by-task.
+
+**Goal:** Every `blob_store-config` carries an `@ <markl-id>` line in
+its hyphence metadata; read paths verify it; legacy configs are
+trusted silently; a migration command and a `madder list` discovery
+surface close the UX loop.
+
+**Architecture:** Hyphence's `TypedMetadataCoder` already writes the
+`@ <markl-id>` line when `TypedBlob.BlobDigest` is non-null
+(`go/internal/charlie/hyphence/coder_metadata.go:56-67`) and parses
+it on read (`coder_metadata.go:26`). All blob_store-config writes
+funnel through a single `Coder.EncodeTo` call in
+`Init.InitBlobStore` (`go/internal/golf/command_components/init.go:55-66`).
+The body-bytes-only digest is computed by tee'ing the encoded body
+into a `blake2b256` hasher around the existing
+`blob_store_configs.Coder.EncodeTo` / `.DecodeFrom` calls. A new
+purpose `madder-blob_store-config-digest-v1` is added to
+`go/internal/bravo/markl/purposes.go` + `markl_registrations/main.go`.
+
+**Tech Stack:** Go, hyphence typed-blob coder, `markl.FormatHash` /
+`markl.AssertEqual`, futility CLI framework, bats integration tests.
+
+**Rollback:** Each task is one revert. The digest field on
+`TypedBlob` is already zero-value-safe. The read-side `AssertEqual`
+is the only new failure mode in production code; revert that single
+call to restore prior behavior. `@` lines left in configs on disk
+are harmless to a reverted binary (hyphence metadata coder already
+keys on `@` for `BlobDigest` and the field is unused if nothing
+re-hashes).
+
+**FDR:** [`docs/features/0008-config-digest-pins.md`](../features/0008-config-digest-pins.md)
+
+---
+
+## Task 1: Register the `madder-blob_store-config-digest-v1` purpose
+
+**Promotion criteria:** N/A (purely additive vocabulary).
+
+**Files:**
+- Modify: `go/internal/bravo/markl/purposes.go` (add constant)
+- Modify: `go/internal/charlie/markl_registrations/main.go`
+  (add `PurposeBlobStoreConfigDigestV1Opts` + append to `AllPurposes`)
+- Test: `go/internal/charlie/markl_registrations/registrations_test.go`
+
+**Step 1: Write the failing test**
+
+Append to `go/internal/charlie/markl_registrations/registrations_test.go`:
+
+```go
+func TestBlobStoreConfigDigestV1Registered(t *testing.T) {
+	purpose := markl.GetPurpose(markl.PurposeBlobStoreConfigDigestV1)
+	if purpose.GetPurposeType() != markl.PurposeTypeBlobDigest {
+		t.Fatalf(
+			"expected PurposeTypeBlobDigest, got %v",
+			purpose.GetPurposeType(),
+		)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```
+just go-test ./go/internal/charlie/markl_registrations/...
+```
+
+Expected: undefined `markl.PurposeBlobStoreConfigDigestV1` compile
+error. If the helper isn't called `go-test`, fall back to
+`go test ./go/internal/charlie/markl_registrations/...` from the
+`go/` directory.
+
+**Step 3: Add the constant**
+
+In `go/internal/bravo/markl/purposes.go`, in the existing const block,
+add a new section after the `// Blob Digests` block:
+
+```go
+	// Blob-Store-Config Digests
+	PurposeBlobStoreConfigDigestV1 = "madder-blob_store-config-digest-v1"
+```
+
+**Step 4: Add the registration**
+
+In `go/internal/charlie/markl_registrations/main.go`, add the opts
+var alongside the others:
+
+```go
+	PurposeBlobStoreConfigDigestV1Opts = markl.RegisterPurposeOpts{
+		Id:   markl.PurposeBlobStoreConfigDigestV1,
+		Type: markl.PurposeTypeBlobDigest,
+		FormatIds: []string{
+			markl.FormatIdHashBlake2b256,
+		},
+	}
+```
+
+Then append to `AllPurposes`:
+
+```go
+	PurposeBlobStoreConfigDigestV1Opts,
+```
+
+**Step 5: Run test to verify it passes**
+
+```
+go test ./go/internal/charlie/markl_registrations/...
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add go/internal/bravo/markl/purposes.go \
+        go/internal/charlie/markl_registrations/main.go \
+        go/internal/charlie/markl_registrations/registrations_test.go
+git commit -m "markl: register madder-blob_store-config-digest-v1 purpose
+
+Phase 1 of FDR-0008. Refs: #194.
+
+:clown: with [Clown](https://github.com/amarbel-llc/clown)"
+```
+
+---
+
+## Task 2: Helper — compute body digest while encoding
+
+The hyphence `Coder.EncodeTo` takes a `*TypedBlob[Config]` whose
+`BlobDigest` is read by `TypedMetadataCoder.EncodeTo` for the `@`
+line. We need to compute the body digest **before** the metadata
+section is written. The cleanest seam is a thin wrapper that
+encodes once to a discard-and-hash sink (to compute the digest),
+then re-encodes for real with `BlobDigest` populated.
+
+This task adds that helper and proves the round-trip on its own
+before any callers switch over.
+
+**Promotion criteria:** Old `Coder.EncodeTo` direct usage in
+`Init.InitBlobStore` is replaced by the new helper in Task 4. The
+helper itself is the only sanctioned write path after Task 4 lands.
+
+**Files:**
+- Create: `go/internal/delta/blob_store_configs/digest.go`
+- Test: `go/internal/delta/blob_store_configs/digest_test.go`
+
+**Step 1: Write the failing test**
+
+Create `go/internal/delta/blob_store_configs/digest_test.go`:
+
+```go
+package blob_store_configs
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/amarbel-llc/madder/go/internal/bravo/markl"
+	"github.com/amarbel-llc/madder/go/internal/charlie/hyphence"
+	_ "github.com/amarbel-llc/madder/go/internal/charlie/markl_registrations"
+)
+
+// TestEncodeWithDigestRoundTrip: encoding a config through
+// EncodeWithDigest produces output whose @ line carries the
+// blake2b256 digest of the body bytes.
+func TestEncodeWithDigestRoundTrip(t *testing.T) {
+	cfg := defaultLocalHashBucketedConfigForTest(t)
+	typedConfig := &TypedConfig{
+		Type: hyphence.MakeType("toml-blob_store_config-v3"),
+		Blob: cfg,
+	}
+
+	var buf bytes.Buffer
+	if _, err := EncodeWithDigest(typedConfig, &buf); err != nil {
+		t.Fatalf("EncodeWithDigest: %v", err)
+	}
+
+	// Decode and confirm the @ line round-trips.
+	decoded := &TypedConfig{}
+	if _, err := Coder.DecodeFrom(decoded, bytes.NewReader(buf.Bytes())); err != nil {
+		t.Fatalf("Coder.DecodeFrom: %v", err)
+	}
+
+	if decoded.BlobDigest.IsNull() {
+		t.Fatal("expected non-null BlobDigest after round-trip")
+	}
+
+	if decoded.BlobDigest.GetMarklFormat().GetMarklFormatId() != markl.FormatIdHashBlake2b256 {
+		t.Fatalf(
+			"expected blake2b256 digest, got %v",
+			decoded.BlobDigest.GetMarklFormat().GetMarklFormatId(),
+		)
+	}
+}
+
+// defaultLocalHashBucketedConfigForTest returns a minimally-valid
+// TomlLocalHashBucketedV3 config suitable for round-trip tests. If
+// blob_store_configs already exposes a helper for this, prefer that
+// over hand-rolling; otherwise hand-roll the simplest valid shape.
+func defaultLocalHashBucketedConfigForTest(t *testing.T) Config {
+	t.Helper()
+	// TODO: replace with the package's preferred test-config builder
+	// if one exists; otherwise construct a TomlV3 with sane defaults.
+	doc, err := charlie_bsc.DecodeTomlV3(nil)
+	if err != nil {
+		t.Fatalf("DecodeTomlV3(nil): %v", err)
+	}
+	return doc.Data()
+}
+```
+
+(If `charlie_bsc` isn't imported in this package, add it as
+`charlie_bsc "github.com/amarbel-llc/madder/go/internal/charlie/blob_store_configs"`.
+If the package already exposes a fixture helper, use that and delete
+the local helper.)
+
+**Step 2: Run test to verify it fails**
+
+```
+go test ./go/internal/delta/blob_store_configs/...
+```
+
+Expected: `EncodeWithDigest` undefined.
+
+**Step 3: Implement `EncodeWithDigest`**
+
+Create `go/internal/delta/blob_store_configs/digest.go`:
+
+```go
+package blob_store_configs
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/amarbel-llc/madder/go/internal/bravo/markl"
+	"github.com/amarbel-llc/purse-first/libs/dewey/bravo/errors"
+)
+
+// DigestPurpose is the markl purpose stamped on the @ line of every
+// migrated blob_store-config.
+const DigestPurpose = markl.PurposeBlobStoreConfigDigestV1
+
+// DigestHash is the hash family used to compute the body digest.
+// Phase 1 hard-codes blake2b256; revisit if a sha256-only store
+// ever needs self-check.
+var DigestHash markl.FormatHash = markl.FormatHashBlake2b256
+
+// EncodeWithDigest renders typedConfig to w with a populated
+// BlobDigest covering the body bytes. It is the only sanctioned
+// write path for blob_store-config files after FDR-0008 Phase 1.
+//
+// Mechanism: render the body to a scratch buffer via Coder.EncodeTo,
+// hash the *body* portion (the bytes that the inner Blob coder
+// emits, not the metadata wrap), stamp typedConfig.BlobDigest with
+// the resulting markl-id, then re-render to w. The double-encode
+// keeps the hash input well-defined (body bytes only) and avoids
+// reworking the hyphence coder's metadata-first emission order.
+func EncodeWithDigest(
+	typedConfig *TypedConfig,
+	w io.Writer,
+) (n int64, err error) {
+	// Pass 1: render body bytes only, no metadata wrap, no hash on the
+	// metadata section. Coder.Blob is the inner CoderTypeMap that
+	// emits the toml-encoded payload; it does not write metadata.
+	var bodyBuf bytes.Buffer
+	if Coder.Blob == nil {
+		err = errors.ErrorWithStackf("Coder.Blob is nil")
+		return n, err
+	}
+
+	bw := newBufWriter(&bodyBuf)
+	if _, err = Coder.Blob.EncodeTo(&typedConfig.Blob, bw); err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+	if err = bw.Flush(); err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+
+	// Hash the body bytes under the configured DigestHash.
+	digest, err := DigestHash.GetMarklIdForBytes(bodyBuf.Bytes())
+	if err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+	if err = digest.SetPurpose(DigestPurpose); err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+	typedConfig.BlobDigest = digest
+
+	// Pass 2: render through the full coder so the @ line and the
+	// metadata header are emitted around the same body bytes.
+	if n, err = Coder.EncodeTo(typedConfig, w); err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+
+	return n, err
+}
+```
+
+You'll need a small `newBufWriter` shim if the inner coder takes a
+`*bufio.Writer`. Check the signature on
+`hyphence.CoderTypeMapWithoutType.EncodeTo` — if it accepts a plain
+`io.Writer`, drop the bufWriter dance.
+
+> NOTE: `EncodeTo` on the inner coder takes a `*bufio.Writer` (see
+> `hyphence.CoderTypeMap`). If `Coder.Blob.EncodeTo`'s second arg is
+> `*bufio.Writer`, build one with `bufio.NewWriter(&bodyBuf)` and
+> flush before measuring.
+
+**Step 4: Run test to verify it passes**
+
+```
+go test ./go/internal/delta/blob_store_configs/...
+```
+
+Expected: PASS.
+
+**Step 5: Add a tamper test**
+
+Append to `digest_test.go`:
+
+```go
+// TestEncodeWithDigestDetectsTamper: mutate one byte of an
+// encoded config; the next Coder.DecodeFrom must surface the
+// mismatch. (The mismatch detection itself is wired in Task 3;
+// this test will gain teeth once Task 3 lands.)
+func TestEncodeWithDigestDetectsTamper(t *testing.T) {
+	cfg := defaultLocalHashBucketedConfigForTest(t)
+	typedConfig := &TypedConfig{
+		Type: hyphence.MakeType("toml-blob_store_config-v3"),
+		Blob: cfg,
+	}
+
+	var buf bytes.Buffer
+	if _, err := EncodeWithDigest(typedConfig, &buf); err != nil {
+		t.Fatalf("EncodeWithDigest: %v", err)
+	}
+
+	// Find the body (after the second hyphence Boundary + blank line)
+	// and flip one byte. The exact offset is implementation-coupled;
+	// use bytes.LastIndex on the boundary marker.
+	bs := buf.Bytes()
+	boundary := []byte("\n---\n\n")
+	idx := bytes.LastIndex(bs, boundary)
+	if idx < 0 {
+		t.Fatalf("could not locate body start in encoded output")
+	}
+	bodyStart := idx + len(boundary)
+	if bodyStart >= len(bs) {
+		t.Fatalf("body is empty in encoded output")
+	}
+	bs[bodyStart] ^= 0x01
+
+	// Task 3 will wire the assertion; for now we only document the
+	// expected post-Task-3 behavior. After Task 3 lands, change this
+	// to assert a markl.ErrNotEqual.
+	decoded := &TypedConfig{}
+	_, _ = Coder.DecodeFrom(decoded, bytes.NewReader(bs))
+	// Intentionally no assertion: Task 3 adds the failure mode.
+}
+```
+
+**Step 6: Commit**
+
+```bash
+git add go/internal/delta/blob_store_configs/digest.go \
+        go/internal/delta/blob_store_configs/digest_test.go
+git commit -m "blob_store_configs: add EncodeWithDigest helper
+
+Phase 1 of FDR-0008. EncodeWithDigest renders a config with its
+BlobDigest populated (body-bytes digest under blake2b256, stamped
+with madder-blob_store-config-digest-v1). The full read-side
+assertion lands in the next task. Refs: #194.
+
+:clown: with [Clown](https://github.com/amarbel-llc/clown)"
+```
+
+---
+
+## Task 3: Read-side self-check — verify @ line on decode
+
+**Promotion criteria:** N/A — once this lands, the FDR's Phase 1
+read-path semantics are live.
+
+**Files:**
+- Create: `go/internal/delta/blob_store_configs/verify.go`
+- Modify: `go/internal/delta/blob_store_configs/digest_test.go`
+  (upgrade the Task 2 tamper test to assert `markl.ErrNotEqual`)
+
+The hyphence `Coder.DecodeFrom` reads metadata first (populating
+`BlobDigest`), then the body. We need to capture the body bytes
+during decode to re-hash them. The simplest way: wrap the
+underlying reader so a hasher tees the post-boundary bytes.
+
+**Step 1: Write the failing test**
+
+Upgrade the tamper test in `digest_test.go`:
+
+```go
+func TestEncodeWithDigestDetectsTamper(t *testing.T) {
+	cfg := defaultLocalHashBucketedConfigForTest(t)
+	typedConfig := &TypedConfig{
+		Type: hyphence.MakeType("toml-blob_store_config-v3"),
+		Blob: cfg,
+	}
+
+	var buf bytes.Buffer
+	if _, err := EncodeWithDigest(typedConfig, &buf); err != nil {
+		t.Fatalf("EncodeWithDigest: %v", err)
+	}
+
+	bs := buf.Bytes()
+	boundary := []byte("\n---\n\n")
+	idx := bytes.LastIndex(bs, boundary)
+	if idx < 0 {
+		t.Fatalf("could not locate body start in encoded output")
+	}
+	bodyStart := idx + len(boundary)
+	bs[bodyStart] ^= 0x01
+
+	decoded := &TypedConfig{}
+	_, err := DecodeAndVerify(decoded, bytes.NewReader(bs))
+	if err == nil {
+		t.Fatal("expected mismatch error, got nil")
+	}
+	var notEqual markl.ErrNotEqual
+	if !errors.As(err, &notEqual) {
+		t.Fatalf("expected markl.ErrNotEqual, got %T: %v", err, err)
+	}
+	if notEqual.Expected.IsNull() || notEqual.Actual.IsNull() {
+		t.Fatal("expected both Expected and Actual to be populated")
+	}
+}
+
+// TestDecodeAndVerifyAcceptsLegacy: a config with no @ line
+// (pre-FDR-0008) is trusted silently.
+func TestDecodeAndVerifyAcceptsLegacy(t *testing.T) {
+	cfg := defaultLocalHashBucketedConfigForTest(t)
+	typedConfig := &TypedConfig{
+		Type: hyphence.MakeType("toml-blob_store_config-v3"),
+		Blob: cfg,
+	}
+
+	// Encode via the legacy coder (no @ line).
+	var buf bytes.Buffer
+	if _, err := Coder.EncodeTo(typedConfig, &buf); err != nil {
+		t.Fatalf("Coder.EncodeTo: %v", err)
+	}
+
+	decoded := &TypedConfig{}
+	if _, err := DecodeAndVerify(decoded, bytes.NewReader(buf.Bytes())); err != nil {
+		t.Fatalf("DecodeAndVerify on legacy config: %v", err)
+	}
+	if !decoded.BlobDigest.IsNull() {
+		t.Fatal("legacy config should not have BlobDigest populated")
+	}
+}
+
+// TestDecodeAndVerifyRoundTrip: encode via EncodeWithDigest, decode
+// via DecodeAndVerify, no error, BlobDigest populated.
+func TestDecodeAndVerifyRoundTrip(t *testing.T) {
+	cfg := defaultLocalHashBucketedConfigForTest(t)
+	typedConfig := &TypedConfig{
+		Type: hyphence.MakeType("toml-blob_store_config-v3"),
+		Blob: cfg,
+	}
+
+	var buf bytes.Buffer
+	if _, err := EncodeWithDigest(typedConfig, &buf); err != nil {
+		t.Fatalf("EncodeWithDigest: %v", err)
+	}
+
+	decoded := &TypedConfig{}
+	if _, err := DecodeAndVerify(decoded, bytes.NewReader(buf.Bytes())); err != nil {
+		t.Fatalf("DecodeAndVerify: %v", err)
+	}
+	if decoded.BlobDigest.IsNull() {
+		t.Fatal("BlobDigest should be populated after round-trip")
+	}
+}
+```
+
+Add `"errors"` to the test file's imports (the stdlib one, for
+`errors.As`).
+
+**Step 2: Run tests to verify they fail**
+
+```
+go test ./go/internal/delta/blob_store_configs/...
+```
+
+Expected: `DecodeAndVerify` undefined.
+
+**Step 3: Implement `DecodeAndVerify`**
+
+Create `go/internal/delta/blob_store_configs/verify.go`:
+
+```go
+package blob_store_configs
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/amarbel-llc/madder/go/internal/bravo/markl"
+	"github.com/amarbel-llc/purse-first/libs/dewey/bravo/errors"
+)
+
+// DecodeAndVerify decodes a blob_store-config from r and, if its
+// metadata carries a BlobDigest, re-hashes the body bytes and
+// asserts the digests match. A config with no @ line is trusted
+// silently (pre-FDR-0008 back-compat). A mismatch returns
+// markl.ErrNotEqual carrying both digests.
+//
+// Implementation: buffer the whole input, run Coder.DecodeFrom on
+// the buffered bytes (which populates BlobDigest from the metadata),
+// then re-encode the decoded *body* via the inner Blob coder and
+// hash that. Buffering the whole config is acceptable because
+// blob_store-config files are bounded in size (KB-scale, not MB).
+func DecodeAndVerify(
+	typedConfig *TypedConfig,
+	r io.Reader,
+) (n int64, err error) {
+	all, err := io.ReadAll(r)
+	if err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+	n = int64(len(all))
+
+	if _, err = Coder.DecodeFrom(typedConfig, bytes.NewReader(all)); err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+
+	if typedConfig.BlobDigest.IsNull() {
+		// Legacy config: no @ line, no assertion.
+		return n, err
+	}
+
+	// Re-encode the body to obtain the canonical byte sequence the
+	// digest covers, then re-hash.
+	var bodyBuf bytes.Buffer
+	bw := bufio.NewWriter(&bodyBuf)
+	if _, err = Coder.Blob.EncodeTo(&typedConfig.Blob, bw); err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+	if err = bw.Flush(); err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+
+	computed, err := DigestHash.GetMarklIdForBytes(bodyBuf.Bytes())
+	if err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+	if err = computed.SetPurpose(DigestPurpose); err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+
+	if err = markl.AssertEqual(typedConfig.BlobDigest, computed); err != nil {
+		err = errors.Wrap(err)
+		return n, err
+	}
+
+	return n, err
+}
+```
+
+Add `"bufio"` to the imports.
+
+> NOTE: The "re-encode the body to obtain the canonical byte
+> sequence" approach assumes the inner Blob coder is **deterministic**
+> for a given Config value. Verify against
+> `go/internal/charlie/blob_store_configs/toml_*` encoders before
+> relying on this. If any encoder emits non-deterministic output
+> (map ordering, timestamp drift), this approach needs the
+> alternative: tee the raw post-boundary bytes through a hasher
+> during the original decode pass. The alternative is a hyphence
+> coder change, not a blob_store_configs change, so deal with it as
+> a sub-task here if necessary.
+
+**Step 4: Run tests to verify they pass**
+
+```
+go test ./go/internal/delta/blob_store_configs/...
+```
+
+Expected: PASS.
+
+**Step 5: Run the wider package suite for regressions**
+
+```
+go test ./go/internal/delta/... ./go/internal/charlie/...
+```
+
+Expected: PASS. If anything fails, investigate — Task 3 should be
+read-side-only and additive.
+
+**Step 6: Commit**
+
+```bash
+git add go/internal/delta/blob_store_configs/verify.go \
+        go/internal/delta/blob_store_configs/digest_test.go
+git commit -m "blob_store_configs: add DecodeAndVerify (read-side self-check)
+
+Phase 1 of FDR-0008. DecodeAndVerify re-hashes the body bytes of a
+decoded config and asserts equality with the @ line's digest via
+markl.AssertEqual. Legacy configs (no @ line) are trusted silently.
+
+Refs: #194.
+
+:clown: with [Clown](https://github.com/amarbel-llc/clown)"
+```
+
+---
+
+## Task 4: Switch `Init.InitBlobStore` to `EncodeWithDigest`
+
+Every `init-*` command funnels through
+`Init.InitBlobStore` (`go/internal/golf/command_components/init.go:17-69`).
+Swap the single `Coder.EncodeTo` call for `EncodeWithDigest`.
+
+**Promotion criteria:** Every `init-*` bats test passes and emits a
+config containing an `@` line. After this lands, no madder write
+path emits a digestless config.
+
+**Files:**
+- Modify: `go/internal/golf/command_components/init.go:55-66`
+- Test: `zz-tests_bats/init.bats` (new test)
+
+**Step 1: Write the failing bats test**
+
+Append to `zz-tests_bats/init.bats`:
+
+```bash
+function init_default_config_has_digest_line { # @test
+  # FDR-0008 Phase 1: every fresh config carries an @ line in its
+  # hyphence metadata header with a blake2b256 digest under the
+  # madder-blob_store-config-digest-v1 purpose.
+  init_store
+
+  local config=".madder/local/share/blob_stores/default/blob_store-config"
+  [[ -f $config ]] || fail "expected config at $config"
+
+  run grep -E '^@ madder-blob_store-config-digest-v1@blake2b256-' "$config"
+  assert_success
+}
+
+function init_inventory_archive_config_has_digest_line { # @test
+  # Same as above for the inventory-archive init path.
+  init_store
+  run_madder init-inventory-archive -encryption none .archive
+  assert_success
+
+  local config=".madder/local/share/blob_stores/archive/blob_store-config"
+  # Path may vary; adjust to whatever init-inventory-archive actually
+  # writes. If the prefix-form needs translation, use the bats helper.
+  [[ -f $config ]] || fail "expected config at $config"
+
+  run grep -E '^@ madder-blob_store-config-digest-v1@blake2b256-' "$config"
+  assert_success
+}
+```
+
+Use whatever recipe runs the bats suite. From the justfile, the
+likely commands are one of `just test-bats`, `just bats`, or
+`just go-bats-tests`. List them first:
+
+```
+just --list | grep -iE 'bats|test'
+```
+
+Then run the new tests only:
+
+```
+just <bats-recipe-name> init
+```
+
+**Step 2: Run tests to verify they fail**
+
+The new tests should fail because the config does not yet contain
+an `@` line. If the migration command line in the test path is
+wrong, fix the path first (the test failure should be "no such
+file" then "no match", not "no such command").
+
+**Step 3: Make the swap**
+
+In `go/internal/golf/command_components/init.go`, change line 60:
+
+```go
+				_, err := blob_store_configs.Coder.EncodeTo(config, w)
+				return err
+```
+
+to:
+
+```go
+				_, err := blob_store_configs.EncodeWithDigest(config, w)
+				return err
+```
+
+**Step 4: Run the bats tests again**
+
+```
+just <bats-recipe-name> init
+```
+
+Expected: PASS, including the new digest-line tests.
+
+**Step 5: Run the full bats init suite**
+
+```
+just <bats-recipe-name>
+```
+
+Expected: PASS for everything. The `init_default_config_is_read_only`
+test at `init.bats:12-22` still passes — mode bits are unchanged.
+
+**Step 6: Commit**
+
+```bash
+git add go/internal/golf/command_components/init.go \
+        zz-tests_bats/init.bats
+git commit -m "init: emit @ digest line in fresh blob_store-configs
+
+Phase 1 of FDR-0008. Init.InitBlobStore is the single write seam for
+every init-* command; switching its blob_store_configs.Coder.EncodeTo
+call to EncodeWithDigest causes every fresh config to carry a body-
+bytes digest under madder-blob_store-config-digest-v1.
+
+Refs: #194.
+
+:clown: with [Clown](https://github.com/amarbel-llc/clown)"
+```
+
+---
+
+## Task 5: Wire `DecodeAndVerify` into every config read path
+
+The decode call sites today are scattered across the foxtrot blob
+stores and golf command_components. Each call to
+`blob_store_configs.Coder.DecodeFrom` becomes a call to
+`DecodeAndVerify`.
+
+**Promotion criteria:** Once this lands, every blob_store-config
+read is tamper-detected. The old `Coder.DecodeFrom` should appear
+only inside `DecodeAndVerify` itself and inside tests.
+
+**Files:**
+- Modify: every file in the grep output below.
+- Test: `go test ./...` and the full bats suite.
+
+**Step 1: Inventory the call sites**
+
+```
+rg -n 'blob_store_configs\.Coder\.DecodeFrom|bsc\.Coder\.DecodeFrom' go/
+```
+
+Expected hits (from earlier exploration): files in
+`go/internal/foxtrot/blob_stores/`,
+`go/internal/golf/command_components/`,
+`go/internal/india/commands/`, and any cutting-garden command.
+Capture the full list before editing.
+
+**Step 2: Add a placeholder failing test**
+
+Create `zz-tests_bats/config_digest_verify.bats`:
+
+```bash
+setup() {
+  load "$(dirname "$BATS_TEST_FILE")/lib/common.bash"
+  export output
+}
+
+# bats file_tags=config_digest
+
+function decode_detects_tampered_config { # @test
+  # FDR-0008 Phase 1: any madder command that reads a
+  # blob_store-config must refuse a tampered one.
+  init_store
+
+  local config=".madder/local/share/blob_stores/default/blob_store-config"
+  [[ -f $config ]] || fail "expected config at $config"
+
+  # The config is 0444. Re-chmod, mutate, re-chmod back.
+  chmod 0644 "$config"
+  # Flip one byte deep in the body. The exact offset is brittle;
+  # appending whitespace is enough to invalidate the body digest
+  # while keeping the toml parseable.
+  printf '\n# tamper\n' >> "$config"
+  chmod 0444 "$config"
+
+  run_madder list
+  assert_failure
+  assert_output --partial 'expected'
+  assert_output --partial 'actual'
+}
+```
+
+**Step 3: Run the bats test to verify it fails (no failure yet)**
+
+```
+just <bats-recipe-name> config_digest
+```
+
+Expected: FAIL — `madder list` still succeeds because no read site
+calls `DecodeAndVerify` yet.
+
+**Step 4: Switch every call site**
+
+For each file from Step 1, replace
+`blob_store_configs.Coder.DecodeFrom(...)` with
+`blob_store_configs.DecodeAndVerify(...)`. The signatures are
+identical (`*TypedConfig, io.Reader`).
+
+Some call sites may pass a `bufio.Reader` or other typed reader —
+`DecodeAndVerify` takes `io.Reader`, so the type checks should hold.
+
+**Step 5: Run the full Go test suite**
+
+```
+go test ./...
+```
+
+Expected: PASS. Anything that fails is either:
+- A test that hand-constructs a config without `EncodeWithDigest` —
+  acceptable, those configs go through the legacy code-path
+  (no `@` line, trusted silently).
+- A test that pre-populates a tampered fixture — change the test
+  to either use `EncodeWithDigest` or expect the new error.
+
+**Step 6: Run the full bats suite**
+
+```
+just <bats-recipe-name>
+```
+
+Expected: PASS, including `decode_detects_tampered_config`.
+
+**Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "blob_store_configs: route every config read through DecodeAndVerify
+
+Phase 1 of FDR-0008. Every site that previously called
+blob_store_configs.Coder.DecodeFrom now calls DecodeAndVerify, so
+tamper detection fires on every read. Legacy configs (no @ line)
+remain trusted silently for back-compat.
+
+Refs: #194.
+
+:clown: with [Clown](https://github.com/amarbel-llc/clown)"
+```
+
+---
+
+## Task 6: New CLI command — `madder config-pin_digest`
+
+**Promotion criteria:** Released as the documented migration path
+for legacy configs. Removable only if Phase 1 is itself reverted.
+
+**Files:**
+- Create: `go/internal/india/commands/config_pin_digest.go`
+- Create: `zz-tests_bats/config_pin_digest.bats`
+- Modify: `docs/man.1/madder.md` (if it lists subcommands; verify)
+
+**Step 1: Write the failing bats test**
+
+Create `zz-tests_bats/config_pin_digest.bats`:
+
+```bash
+setup() {
+  load "$(dirname "$BATS_TEST_FILE")/lib/common.bash"
+  export output
+}
+
+# bats file_tags=config_pin_digest
+
+function config_pin_digest_mints_on_legacy { # @test
+  # Construct a legacy config (no @ line), run config-pin_digest,
+  # confirm the config now has one.
+  init_store
+
+  local config=".madder/local/share/blob_stores/default/blob_store-config"
+  chmod 0644 "$config"
+  # Strip any @ line to simulate a pre-FDR-0008 config.
+  sed -i.bak '/^@ /d' "$config" && rm "$config.bak"
+  chmod 0444 "$config"
+
+  run grep -E '^@ madder-blob_store-config-digest-v1@' "$config"
+  assert_failure  # confirm legacy shape
+
+  run_madder config-pin_digest default
+  assert_success
+
+  run grep -E '^@ madder-blob_store-config-digest-v1@blake2b256-' "$config"
+  assert_success
+}
+
+function config_pin_digest_idempotent { # @test
+  init_store
+
+  run_madder config-pin_digest default
+  assert_success
+
+  local config=".madder/local/share/blob_stores/default/blob_store-config"
+  local before
+  before=$(cat "$config")
+
+  run_madder config-pin_digest default
+  assert_success
+
+  local after
+  after=$(cat "$config")
+  assert_equal "$before" "$after"
+}
+
+function config_pin_digest_all { # @test
+  init_store
+  run_madder init-inventory-archive -encryption none .archive
+  assert_success
+
+  # Strip @ lines from both configs.
+  for config in \
+    .madder/local/share/blob_stores/default/blob_store-config \
+    .madder/local/share/blob_stores/archive/blob_store-config
+  do
+    chmod 0644 "$config"
+    sed -i.bak '/^@ /d' "$config" && rm "$config.bak"
+    chmod 0444 "$config"
+  done
+
+  run_madder config-pin_digest --all
+  assert_success
+
+  for config in \
+    .madder/local/share/blob_stores/default/blob_store-config \
+    .madder/local/share/blob_stores/archive/blob_store-config
+  do
+    run grep -E '^@ madder-blob_store-config-digest-v1@blake2b256-' "$config"
+    assert_success
+  done
+}
+
+function config_pin_digest_rejects_no_target { # @test
+  init_store
+  run_madder config-pin_digest
+  assert_failure
+  assert_output --partial 'specify --all or one or more blob-store-ids'
+}
+
+function config_pin_digest_rejects_both_modes { # @test
+  init_store
+  run_madder config-pin_digest --all default
+  assert_failure
+  assert_output --partial '--all and explicit ids are mutually exclusive'
+}
+```
+
+**Step 2: Run the bats tests to verify they fail**
+
+```
+just <bats-recipe-name> config_pin_digest
+```
+
+Expected: FAIL — command not registered.
+
+**Step 3: Implement the command**
+
+Create `go/internal/india/commands/config_pin_digest.go`:
+
+```go
+package commands
+
+import (
+	"io"
+
+	"github.com/amarbel-llc/madder/go/internal/alfa/blob_store_id"
+	"github.com/amarbel-llc/madder/go/internal/charlie/files"
+	"github.com/amarbel-llc/madder/go/internal/delta/blob_store_configs"
+	"github.com/amarbel-llc/madder/go/internal/foxtrot/blob_stores"
+	"github.com/amarbel-llc/madder/go/internal/futility"
+	"github.com/amarbel-llc/madder/go/internal/golf/command_components"
+	"github.com/amarbel-llc/purse-first/libs/dewey/0/interfaces"
+	"github.com/amarbel-llc/purse-first/libs/dewey/bravo/errors"
+)
+
+func init() {
+	utility.AddCmd("config-pin_digest", &ConfigPinDigest{})
+}
+
+// ConfigPinDigest re-emits the named blob_store-config files with
+// their @ digest line populated. Idempotent: a config that already
+// has a matching @ line is decoded and re-emitted byte-identical.
+type ConfigPinDigest struct {
+	command_components.EnvBlobStore
+
+	All bool
+}
+
+var (
+	_ interfaces.CommandComponentWriter = (*ConfigPinDigest)(nil)
+	_ futility.CommandWithParams        = (*ConfigPinDigest)(nil)
+)
+
+func (cmd *ConfigPinDigest) GetParams() []futility.Param {
+	return []futility.Param{
+		{
+			Name:        "blob-store-id",
+			Description: "blob-store-id(s) to migrate; omit when --all is set",
+			Repeats:     true,
+		},
+	}
+}
+
+func (cmd ConfigPinDigest) GetDescription() futility.Description {
+	return futility.Description{
+		Short: "mint or refresh the @ digest line on blob_store-config files",
+		Long: "Re-emits the named blob_store-config files with their " +
+			"@ digest line populated. Idempotent: a config that already " +
+			"carries a matching digest is re-emitted byte-identical. " +
+			"Required reading: docs/features/0008-config-digest-pins.md.",
+	}
+}
+
+func (cmd *ConfigPinDigest) SetFlagDefinitions(
+	flagSet interfaces.CLIFlagDefinitions,
+) {
+	flagSet.BoolVar(&cmd.All, "all", false,
+		"migrate every blob_store-config under the active XDG roots")
+}
+
+func (cmd ConfigPinDigest) Run(req futility.Request) {
+	args := req.GetPositionalArgs()
+
+	if cmd.All && len(args) > 0 {
+		req.Cancel(errors.Errorf(
+			"--all and explicit ids are mutually exclusive",
+		))
+		return
+	}
+	if !cmd.All && len(args) == 0 {
+		req.Cancel(errors.Errorf(
+			"specify --all or one or more blob-store-ids",
+		))
+		return
+	}
+
+	envBlobStore := cmd.MakeEnvBlobStore(req)
+	blobStoreMap := envBlobStore.GetBlobStores()
+
+	var targets []blob_stores.BlobStoreInitialized
+	if cmd.All {
+		for _, bs := range blobStoreMap {
+			targets = append(targets, bs)
+		}
+	} else {
+		for _, arg := range args {
+			var id blob_store_id.Id
+			if err := id.Set(arg); err != nil {
+				req.Cancel(errors.Wrapf(err,
+					"invalid blob-store-id: %q", arg))
+				return
+			}
+			bs, ok := blobStoreMap[id]
+			if !ok {
+				req.Cancel(errors.Errorf(
+					"no such blob store: %q", arg))
+				return
+			}
+			targets = append(targets, bs)
+		}
+	}
+
+	for _, target := range targets {
+		if err := cmd.migrate(target); err != nil {
+			req.Cancel(errors.Wrapf(err,
+				"failed to migrate %q",
+				target.Path.GetId(),
+			))
+			return
+		}
+	}
+}
+
+func (cmd ConfigPinDigest) migrate(
+	target blob_stores.BlobStoreInitialized,
+) error {
+	configPath := target.Path.GetConfig()
+	typedConfig := &blob_store_configs.TypedConfig{}
+
+	f, err := files.OpenReadOnly(configPath)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	if _, err = blob_store_configs.DecodeAndVerify(typedConfig, f); err != nil {
+		_ = f.Close()
+		return errors.Wrap(err)
+	}
+	if err = f.Close(); err != nil {
+		return errors.Wrap(err)
+	}
+
+	// Clear BlobDigest so EncodeWithDigest recomputes (covers the
+	// case where the input was legacy and BlobDigest was null).
+	typedConfig.BlobDigest = markl.Id{}
+
+	return files.WriteImmutable(configPath, func(w io.Writer) error {
+		_, err := blob_store_configs.EncodeWithDigest(typedConfig, w)
+		return err
+	})
+}
+```
+
+> NOTE: The exact `files.OpenReadOnly` / `files.WriteImmutable` API
+> calls may differ — confirm by reading `go/internal/charlie/files/`
+> and matching the helpers used in `Init.InitBlobStore`. Also verify
+> the `BlobStoreMap` key type before indexing with the parsed `Id`;
+> if the map is keyed by `string` (canonical form), use
+> `id.Canonical()` as the key.
+
+**Step 4: Run the bats tests**
+
+```
+just <bats-recipe-name> config_pin_digest
+```
+
+Expected: PASS.
+
+**Step 5: Run the full bats suite for regressions**
+
+```
+just <bats-recipe-name>
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add go/internal/india/commands/config_pin_digest.go \
+        zz-tests_bats/config_pin_digest.bats
+git commit -m "commands: add 'madder config-pin_digest' migration command
+
+Phase 1 of FDR-0008. Mints or refreshes the @ digest line on
+blob_store-config files. Accepts one or more blob-store-ids or
+--all (mutually exclusive). Idempotent. Refs: #194.
+
+:clown: with [Clown](https://github.com/amarbel-llc/clown)"
+```
+
+---
+
+## Task 7: `madder list` — show digest in text/ndjson/json, flag legacy
+
+**Promotion criteria:** Released as the documented discovery path
+for the upgrade. Removable only if Phase 1 itself is reverted.
+
+**Files:**
+- Modify: `go/internal/india/commands/list.go:60-141`
+- Test: `zz-tests_bats/list*.bats` (if a file exists; otherwise
+  add cases to a new `list.bats`)
+
+**Step 1: Write the failing bats test**
+
+Check whether `zz-tests_bats/list.bats` exists:
+
+```
+ls zz-tests_bats/list*.bats 2>/dev/null
+```
+
+If it doesn't, create one:
+
+```bash
+setup() {
+  load "$(dirname "$BATS_TEST_FILE")/lib/common.bash"
+  export output
+}
+
+# bats file_tags=list
+
+function list_shows_digest_for_migrated { # @test
+  init_store
+  run_madder list
+  assert_success
+  assert_output --regexp 'default@blake2b256-'
+}
+
+function list_flags_unmigrated_with_footer { # @test
+  init_store
+  local config=".madder/local/share/blob_stores/default/blob_store-config"
+  chmod 0644 "$config"
+  sed -i.bak '/^@ /d' "$config" && rm "$config.bak"
+  chmod 0444 "$config"
+
+  run_madder list
+  assert_success
+  assert_output --partial '(unmigrated)'
+  assert_output --partial 'madder config-pin_digest default'
+}
+
+function list_no_footer_when_all_migrated { # @test
+  init_store
+  run_madder list
+  assert_success
+  refute_output --partial 'config-pin_digest'
+  refute_output --partial '(unmigrated)'
+}
+
+function list_ndjson_includes_digest { # @test
+  init_store
+  run_madder list -format=ndjson
+  assert_success
+  assert_output --partial '"digest":"madder-blob_store-config-digest-v1@blake2b256-'
+}
+
+function list_ndjson_flags_legacy { # @test
+  init_store
+  local config=".madder/local/share/blob_stores/default/blob_store-config"
+  chmod 0644 "$config"
+  sed -i.bak '/^@ /d' "$config" && rm "$config.bak"
+  chmod 0444 "$config"
+
+  run_madder list -format=ndjson
+  assert_success
+  assert_output --partial '"digest_missing":true'
+}
+```
+
+**Step 2: Run the tests to verify they fail**
+
+```
+just <bats-recipe-name> list
+```
+
+Expected: FAIL — `madder list` does not yet emit digests or
+footers.
+
+**Step 3: Modify `emitListText`, `emitListNDJSON`, `makeListRecord`**
+
+In `go/internal/india/commands/list.go`:
+
+```go
+type listRecord struct {
+	Id             string `json:"id"`
+	Description    string `json:"description"`
+	ConfigPath     string `json:"config_path"`
+	Base           string `json:"base"`
+	Digest         string `json:"digest,omitempty"`
+	DigestMissing  bool   `json:"digest_missing,omitempty"`
+}
+
+func makeListRecord(blobStore blob_stores.BlobStoreInitialized) listRecord {
+	rec := listRecord{
+		Id:          blobStore.Path.GetId().String(),
+		Description: blobStore.GetBlobStoreDescription(),
+		ConfigPath:  blobStore.Path.GetConfig(),
+		Base:        blobStore.Path.GetBase(),
+	}
+	if d := blobStoreConfigDigest(blobStore); !d.IsNull() {
+		rec.Digest = d.String()
+	} else {
+		rec.DigestMissing = true
+	}
+	return rec
+}
+
+// blobStoreConfigDigest extracts the digest from an initialized
+// blob store's already-decoded config. The BlobStoreInitialized
+// struct should already hold the TypedConfig from discovery; if
+// not, decode it on demand via DecodeAndVerify.
+func blobStoreConfigDigest(
+	blobStore blob_stores.BlobStoreInitialized,
+) markl.Id {
+	// TODO: thread the decoded TypedConfig through
+	// BlobStoreInitialized so this lookup is O(1). For now,
+	// re-read the config from disk.
+	f, err := files.OpenReadOnly(blobStore.Path.GetConfig())
+	if err != nil {
+		return markl.Id{}
+	}
+	defer f.Close()
+	var typedConfig blob_store_configs.TypedConfig
+	if _, err := blob_store_configs.DecodeAndVerify(&typedConfig, f); err != nil {
+		return markl.Id{}
+	}
+	return typedConfig.BlobDigest
+}
+
+func emitListText(
+	envBlobStore command_components.BlobStoreEnv,
+	blobStores blob_stores.BlobStoreMap,
+) {
+	var unmigrated []string
+	for _, blobStore := range stableOrder(blobStores) {
+		idStr := blobStore.Path.GetId().String()
+		digest := blobStoreConfigDigest(blobStore)
+		if !digest.IsNull() {
+			idStr = idStr + "@" + digest.String()
+		} else {
+			idStr = idStr + " (unmigrated)"
+			unmigrated = append(unmigrated, blobStore.Path.GetId().String())
+		}
+		envBlobStore.GetUI().Printf(
+			"%s: %s # path: %s",
+			idStr,
+			blobStore.GetBlobStoreDescription(),
+			envBlobStore.RelToCwdOrSame(blobStore.Path.GetConfig()),
+		)
+	}
+	if len(unmigrated) > 0 {
+		envBlobStore.GetUI().Printf("")
+		envBlobStore.GetUI().Printf(
+			"NOTE: %d store(s) above are missing tamper-detection digests.",
+			len(unmigrated),
+		)
+		envBlobStore.GetUI().Printf("      Run this to migrate them:")
+		envBlobStore.GetUI().Printf("")
+		envBlobStore.GetUI().Printf(
+			"        madder config-pin_digest %s",
+			strings.Join(unmigrated, " "),
+		)
+	}
+}
+```
+
+Add `"strings"`, `"github.com/amarbel-llc/madder/go/internal/bravo/markl"`,
+`"github.com/amarbel-llc/madder/go/internal/charlie/files"`,
+`"github.com/amarbel-llc/madder/go/internal/delta/blob_store_configs"`
+to the imports.
+
+> NOTE: The digest-extraction via re-reading is wasteful. A
+> follow-up should thread `TypedConfig` through
+> `BlobStoreInitialized` so the field is available without an extra
+> disk read. Captured as #TODO in the FDR's Future Work.
+
+**Step 4: Run the list tests**
+
+```
+just <bats-recipe-name> list
+```
+
+Expected: PASS for all five tests.
+
+**Step 5: Run the full bats suite**
+
+```
+just <bats-recipe-name>
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add go/internal/india/commands/list.go \
+        zz-tests_bats/list.bats
+git commit -m "list: show config digest, flag legacy, emit migration footer
+
+Phase 1 of FDR-0008. `madder list` now shows the digest-bearing
+ID form for migrated stores, marks legacy stores with
+(unmigrated), and prints a copy-pasteable
+'madder config-pin_digest …' footer listing exactly the unmigrated
+store IDs when any are present. The ndjson/json modes gain
+`digest` and `digest_missing` fields per FDR-0008.
+
+Refs: #194, #174, #175.
+
+:clown: with [Clown](https://github.com/amarbel-llc/clown)"
+```
+
+---
+
+## Task 8: Documentation pass
+
+**Files:**
+- Modify: `docs/man.7/blob-store.md`
+- Modify: `docs/man.1/madder.md` (if it lists subcommands)
+- Modify: `docs/features/0008-config-digest-pins.md` (status →
+  `experimental`)
+
+**Step 1: Update `blob-store(7)`**
+
+In `docs/man.7/blob-store.md`, add a new section before
+`# CONCURRENCY AND DURABILITY`:
+
+```markdown
+# CONFIG TAMPER DETECTION
+
+Every blob_store-config carries an `@` line in its hyphence
+metadata header recording a `blake2b256` digest of the config's body
+bytes (purpose `madder-blob_store-config-digest-v1`). On read, madder
+recomputes the digest and refuses to use a config whose body does
+not match. Legacy configs (no `@` line) are trusted silently for
+backward compatibility; **`madder list`** flags them and prints a
+copy-pasteable **`madder config-pin_digest`** command to migrate.
+
+The digest covers the config's body only. Filesystem permissions,
+the parent directory's identity, and the blob contents the config
+points at are out of scope.
+
+See FDR 0008 for the full design.
+```
+
+**Step 2: Promote the FDR status**
+
+In `docs/features/0008-config-digest-pins.md` frontmatter, change
+`status: proposed` to `status: experimental` once Tasks 1-7 are
+merged.
+
+**Step 3: Commit**
+
+```bash
+git add docs/man.7/blob-store.md docs/features/0008-config-digest-pins.md
+git commit -m "docs: document config tamper detection in blob-store(7)
+
+Promote FDR-0008 from proposed to experimental now that Phase 1 has
+landed.
+
+Refs: #194.
+
+:clown: with [Clown](https://github.com/amarbel-llc/clown)"
+```
+
+---
+
+## Out of scope (Phase 2 follow-up plan)
+
+Not in this plan:
+
+- `blob_store_id.Id` text-form extension (`name@<markl-id>`)
+- Resolver-side `AssertEqual` against the ID's digest
+- "Digest against unmigrated config" error
+- Persisting digest-bearing IDs in receipts/inventory archives
+- Absolute-path location type
+
+Those land in a Phase 2 plan after this plan's tasks ship.

--- a/zz-tests_bats/justfile
+++ b/zz-tests_bats/justfile
@@ -15,17 +15,22 @@ test-tags *tags:
     bats --jobs {{num_cpus()}} --filter-tags {{tags}} *.bats
 
 # Run the default integration test suite. Excludes net_cap-tagged
-# tests (loopback-binding scenarios) — those run under `test-net-cap`
-# with sandcastle's --allow-local-binding granted.
+# tests (loopback-binding scenarios) — those run under `test-net-cap`.
 [group("test")]
 test:
   BATS_TEST_TIMEOUT="{{bats_timeout}}" \
     bats --jobs {{num_cpus()}} --filter-tags '!net_cap' *.bats
 
-# Run net_cap-tagged tests with --allow-local-binding so sandcastle
-# permits 127.0.0.1 binds, and --allow-unix-sockets so the
-# sftp-analyze harness's per-test ssh-agent can listen on a
-# tmpdir-relative Unix socket. Used for the SFTP test family.
+# Run net_cap-tagged tests (loopback-binding + unix-socket SFTP harness).
+#
+# The historical --allow-local-binding / --allow-unix-sockets flags
+# were sandcastle-era and no longer exist in upstream bats. The
+# capabilities they used to grant are now provided by the nix sandbox
+# itself (fresh netns with loopback up; unix sockets under TMPDIR work
+# without grants). See clown ADR-0007 for the empirical write-up.
+# Retiring the net_cap tag entirely is tracked separately; for now the
+# tag still exists and the recipe still runs the tagged tests, just
+# without the obsolete flags.
 #
 # TMPDIR=/tmp pins the per-test tmpdir to a short prefix. macOS's
 # default $TMPDIR is a long per-user path, and our session $TMPDIR is
@@ -36,4 +41,4 @@ test:
 [group("test")]
 test-net-cap:
   TMPDIR=/tmp BATS_TEST_TIMEOUT="{{bats_timeout}}" \
-    bats --allow-local-binding --allow-unix-sockets --jobs {{num_cpus()}} --filter-tags net_cap *.bats
+    bats --jobs {{num_cpus()}} --filter-tags net_cap *.bats


### PR DESCRIPTION
## Summary

Documentation-only PR establishing FDR-0008 (config digest pins) and a
detailed Phase 1 implementation plan. Origin: #194.

Three commits:

1. `b5eb32e` — **FDR-0008** at `docs/features/0008-config-digest-pins.md`.
   Two-phase design:
   - **Phase 1**: `blob_store-config` carries an `@ <markl-id>` self-
     check line in its hyphence metadata; read paths recompute and
     `markl.AssertEqual`; legacy configs (no `@` line) trusted
     silently for back-compat. New `madder config-pin_digest` command
     mints the line on legacy configs. `madder list` shows the
     digest-bearing ID form for migrated stores and emits a copy-
     pasteable migration footer for unmigrated ones.
   - **Phase 2**: optional `name@<digest>` suffix on blob-store-ids
     (e.g. `default@blake2b256-…`), `AssertEqual`'d against the
     config's Phase 1 digest at resolve time.

2. `c676e47` — **Phase 1 implementation plan** at
   `docs/plans/2026-05-17-config-digest-pins-phase1.md`. Eight
   TDD-shaped tasks with exact paths, code, commands, and commit
   instructions. Key seam discovery during planning:
   `Init.InitBlobStore` at
   `go/internal/golf/command_components/init.go:55-66` is the single
   write site for every `init-*` command, so Phase 1's emit-side
   change is a one-call swap rather than touching every init
   command.

3. `6aa0c86` — **bats fix**: drop sandcastle-era
   `--allow-local-binding` / `--allow-unix-sockets` flags from
   `zz-tests_bats/justfile`'s `test-net-cap` recipe. Upstream bats
   no longer recognizes these flags (sandcastle was removed when
   batman moved from `amarbel-llc/bob` to `amarbel-llc/bats`). This
   unblocks the recipe's argv parse but does **not** by itself make
   the `net_cap` tests pass on this host — see "Pre-merge hook
   status" below.

## Pre-merge hook status

The pre-merge hook (`just`) fails on this branch in two ways and
both are pre-existing, not introduced here:

- Before `6aa0c86`: `test-net-cap` failed at `bats` argv parse
  because the sandcastle flags are gone from upstream.
- After `6aa0c86`: the `net_cap`-tagged WebDAV tests fail at
  setup with `listen tcp 127.0.0.1:0: bind: operation not
  permitted`. The skill `eng:wiring-bats-tests` claims the nix
  sandbox grants loopback unconditionally, but that's not what
  happens on this host. The real fix is the bob→bats migration
  tracked in #200, where the new `mkBats` wrapper takes over the
  capability story.

The three commits here are **docs-only plus one comment fix** on a
test recipe. The integration-test breakage predates this branch
and is not caused by anything in the diff.

## Companion issues

- **#194** — Origin (explore issue, still open until both phases ship)
- **#197** — Phase 1 implementation tracking issue
- **#198** — Phase 2 implementation tracking issue
- **#199** — Future RFC: absolute-path location type for blob-store-ids
- **#200** — bats wiring migration from bob to amarbel-llc/bats

## Merge guidance

Two options for the reviewer:

1. **Bypass the pre-merge hook** (or override via the
   force-merge path) — the changes are docs-only plus a single
   test-recipe comment/flag tweak; they cannot have caused the
   integration-test failure.
2. **Land #200 first**, then re-run the pre-merge hook on this
   branch. Cleaner but blocks the docs on unrelated CI work.

:clown: opened with [Clown](https://github.com/amarbel-llc/clown)