### PR TITLE
test(sftp_legacy): bind ssh-agent socket via `-a /tmp/.../sock` (fixes #207)

### DIFF
--- a/zz-tests_bats/lib/sftp_legacy.bash
+++ b/zz-tests_bats/lib/sftp_legacy.bash
@@ -9,58 +9,44 @@
 # with stop_test_ssh_agent in teardown. madder's
 # MakeSSHClientFromSSHConfig uses pubkey-via-agent auth.
 #
-# TMPDIR=/tmp scopes ssh-agent's socket dir to a short path:
-# $BATS_TEST_TMPDIR plus any worktree-rooted session TMPDIR can
-# blow past the 108-char Unix domain socket limit. ssh-agent cleans
-# up the socket dir on the SIGTERM that stop_test_ssh_agent sends.
+# The agent socket is bound under a fresh /tmp/-rooted dir via
+# `ssh-agent -a`. We cannot rely on $TMPDIR for the socket location:
+# inside the macOS nix build sandbox bats sits under a long $TMPDIR
+# (/nix/var/nix/builds/nix-NNNNN-NNNNNNNNN) and $BATS_TEST_TMPDIR
+# inherits that prefix, so the agent's default listener dir
+# overruns darwin's 104-byte AF_UNIX sun_path limit. The kernel
+# stores the literal path passed to bind(2), so an explicit
+# `-a /tmp/.../agent.sock` keeps the bound path short regardless of
+# where bats's per-test tree lives. See madder#207.
 start_test_ssh_agent() {
   local key="$BATS_TEST_TMPDIR/test_ed25519"
 
   ssh-keygen -t ed25519 -N '' -f "$key" -q
 
-  # DEBUG (madder#207): on the darwin nix sandbox the TMPDIR=/tmp prefix
-  # below does not actually shorten the agent socket path — every test
-  # fails with `unix_listener_tmp: ... too long for Unix domain socket`.
-  # These probes write to stderr so bats captures them in the TAP output
-  # for the next macOS-15 CI run, letting us tell apart "ssh-agent on
-  # darwin ignores $TMPDIR", "bats reset TMPDIR before this helper ran",
-  # and "/tmp is not writable inside the macOS sandbox". Drop once the
-  # real fix lands.
-  {
-    printf 'debug-#207: uname=%s TMPDIR=%s BATS_TEST_TMPDIR=%s\n' \
-      "$(uname)" "${TMPDIR:-<unset>}" "${BATS_TEST_TMPDIR:-<unset>}"
-    for cand in /tmp /var/tmp /private/tmp; do
-      if touch "$cand/m207-probe.$$" 2>/dev/null; then
-        printf 'debug-#207: %s writable\n' "$cand"
-        rm -f "$cand/m207-probe.$$"
-      else
-        printf 'debug-#207: %s NOT writable\n' "$cand"
-      fi
-    done
-  } >&2
+  local sock_dir
+  sock_dir=$(mktemp -d /tmp/mdr.XXXXXX)
+  TEST_SSH_AGENT_SOCK_DIR="$sock_dir"
 
-  local agent_output agent_rc=0
-  agent_output="$(TMPDIR=/tmp ssh-agent -s 2>&1)" || agent_rc=$?
-  printf 'debug-#207: ssh-agent rc=%d output:\n%s\n' "$agent_rc" "$agent_output" >&2
-  if [[ "$agent_rc" -ne 0 ]]; then
-    return "$agent_rc"
-  fi
+  local agent_output
+  agent_output="$(ssh-agent -a "$sock_dir/agent.sock" -s)"
   eval "$agent_output" >/dev/null
-
-  printf 'debug-#207: SSH_AUTH_SOCK=%s SSH_AGENT_PID=%s\n' \
-    "${SSH_AUTH_SOCK:-<unset>}" "${SSH_AGENT_PID:-<unset>}" >&2
 
   ssh-add "$key" 2>/dev/null
 
   export SSH_AUTH_SOCK
   export SSH_AGENT_PID
   export TEST_SSH_AGENT_KEY="$key"
+  export TEST_SSH_AGENT_SOCK_DIR
 }
 
 stop_test_ssh_agent() {
   if [[ -n ${SSH_AGENT_PID:-} ]]; then
     kill "$SSH_AGENT_PID" 2>/dev/null || true
     unset SSH_AGENT_PID
+  fi
+  if [[ -n ${TEST_SSH_AGENT_SOCK_DIR:-} ]]; then
+    rm -rf "$TEST_SSH_AGENT_SOCK_DIR"
+    unset TEST_SSH_AGENT_SOCK_DIR
   fi
   unset SSH_AUTH_SOCK TEST_SSH_AGENT_KEY
 }


### PR DESCRIPTION
Fixes #207 — the macOS-15 nix `bats-net_cap` lane has been red on
every PR since the dewey bump because `unix_listener_tmp: path "..."
too long for Unix domain socket` knocks out every `net_cap` test in
its setup phase.

## What's going on

The diagnostic landed in d77cdac on master confirmed three things:

- `$TMPDIR` at the start of `start_test_ssh_agent` is the nix build
  sandbox dir (`/nix/var/nix/builds/nix-NNNNN-NNNNNNNNN`), set by
  nix before bats even starts.
- `/tmp`, `/var/tmp`, and `/private/tmp` are all writable inside the
  darwin nix sandbox — short paths exist, sandbox relaxation is not
  needed.
- The previous helper's `TMPDIR=/tmp ssh-agent -s` form did **not**
  shorten the socket path on darwin. By the time the helper ran,
  `$BATS_TEST_TMPDIR` was already rooted under the long sandbox
  `$TMPDIR`, and ssh-agent's listener directory inherits from
  there. The `TMPDIR=/tmp` argv prefix to `ssh-agent` arrived too
  late.

The local `zz-tests_bats/justfile:32-37` already documents this
failure mode for devshell runs, where the workaround is "set
`TMPDIR=/tmp` *before* bats starts." The CI lane has no equivalent
hook — nix's build sandbox owns `$TMPDIR`.

## Fix

Drop the `TMPDIR`-prefix approach in `start_test_ssh_agent` and
instead bind the agent socket via an explicit `ssh-agent -a
"$sock_dir/agent.sock"`, with `$sock_dir` freshly created via
`mktemp -d /tmp/mdr.XXXXXX`. The kernel stores the literal path
passed to `bind(2)`, so the bound path is
`/tmp/mdr.XXXXXX/agent.sock` (~26 bytes) plus ssh-agent's
`unix_listener_tmp` suffix — well under darwin's 104-byte
`sun_path` cap, regardless of how long bats's per-test tree is.

`stop_test_ssh_agent` removes the per-agent `/tmp/mdr.XXXXXX` dir on
teardown, threaded through the new `TEST_SSH_AGENT_SOCK_DIR` export.

The diagnostic block from d77cdac is removed in the same commit —
it served its purpose. The PR is one commit so a squash-merge is
fine.

## Risk

- linux `net_cap`: already green with the `TMPDIR`-prefix form;
  stays green with this one. The change isn't load-bearing on
  linux — sandbox path stays under 108 either way.
- darwin `net_cap`: the whole point of this PR; expected to flip
  from all-red to all-green.

## Verification

- Linux `just` (default lane) runs locally — `bats-net_cap` derivation
  builds clean, all 70 tests pass (verified during the spinclass
  pre-merge hook on the prior commit on this branch and again
  before this push).
- macOS-15 lane: this PR's CI run is the proof point.

Closes #207.

:clown: by [Clown](https://github.com/amarbel-llc/clown)