### PR TITLE
Wire tommy as conformist TOML formatter + codegen linter

### DIFF
--- a/conformist.toml
+++ b/conformist.toml
@@ -44,7 +44,30 @@ command = "shfmt"
 options = ["-w", "-i", "2", "-s", "-ci"]
 includes = ["*.sh", "*.bash", "*.bats"]
 
+# TOML via tommy's CST-preserving formatter (`tommy fmt`). conformist.toml itself
+# is excluded above (intentional layout).
+[formatter.tommy]
+command = "tommy"
+options = ["fmt"]
+includes = ["*.toml"]
+
 # Linter: shellcheck runs read-only in `conformist check` (no autofix).
 [linter.shellcheck]
 command = "shellcheck"
 includes = ["*.sh", "*.bash", "*.bats"]
+
+# tommy codegen as a REPAIR linter: `conformist` / `nix fmt` / `conformist
+# --commit` runs `tommy generate` for every `//go:generate tommy generate` source
+# file (the blob_store_configs *_tommy.go), so regenerated codegen lands in the
+# auto-fix chore. The driver self-gates on tommy + go (present in the devshell
+# `just fmt` / `just lint-fmt` run under), so it is a no-op where the toolchain is
+# absent. The CHECK command is a deliberate no-op (`true`) so `conformist check`
+# never reports false codegen drift — `tommy generate --check` compares against
+# tommy's raw render, which differs from the committed file once it is re-run
+# through the formatter (see `just generate-tommy`); true staleness stays gated by
+# that recipe. passes-files=false: the driver walks the tree for the directive.
+[linter.tommy-codegen]
+command = "true"
+repair-command = "conformist-tommy-codegen"
+includes = ["*.go", "**/*.go"]
+passes-files = false

--- a/flake.nix
+++ b/flake.nix
@@ -146,6 +146,11 @@
             pkgs.nixfmt
             pkgs.shfmt
             pkgs.shellcheck
+            # tommy (TOML formatter, [formatter.tommy]) + the codegen driver
+            # ([linter.tommy-codegen]) so `nix fmt` resolves both. result is
+            # defined below in this recursive let.
+            tommy.packages.${system}.default
+            result.tommyCodegen
           ];
           text = ''exec conformist "$@"'';
         };

--- a/go/default.nix
+++ b/go/default.nix
@@ -48,47 +48,13 @@ let
   pkgs = import nixpkgs { inherit system; };
   pkgs-master = import nixpkgs-master { inherit system; };
 
-  # tommy codegen as a conformist linter driver. Walks the tree for
-  # `//go:generate tommy generate` directives and runs `tommy generate` per file
-  # (REPAIR mode; the conformist.toml CHECK command is a no-op `true`). Resolves
-  # tommy + go from the AMBIENT PATH and skips (exit 0) when either is missing,
-  # so it is a safe no-op where the toolchain is absent and regenerates the
-  # blob_store_configs *_tommy.go in the devshell (where tommy + go are present),
+  # tommy's conformist codegen linter driver ([linter.tommy-codegen]), owned by
+  # the tommy flake so the pinned tommy input resolves which tommy backs it (no
+  # per-repo driver duplication). It bakes that tommy in and skips when go is
+  # absent. Regenerates the blob_store_configs *_tommy.go in the devshell,
   # landing in the `conformist --commit` chore. Exposed below so the conformistFmt
   # wrapper in flake.nix can put it on the `nix fmt` PATH too.
-  tommyCodegen = pkgs.writeShellApplication {
-    name = "conformist-tommy-codegen";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.findutils
-      pkgs.gnugrep
-    ];
-    text = ''
-      mode="repair"
-      if [ "''${1:-}" = "--check" ]; then
-        mode="check"
-      fi
-      if ! command -v tommy >/dev/null 2>&1; then
-        echo "tommy-codegen: tommy not on PATH; skipping" >&2
-        exit 0
-      fi
-      if ! command -v go >/dev/null 2>&1; then
-        echo "tommy-codegen: go not on PATH; skipping" >&2
-        exit 0
-      fi
-      status=0
-      while IFS= read -r f; do
-        dir=$(dirname "$f")
-        base=$(basename "$f")
-        if [ "$mode" = "check" ]; then
-          ( cd "$dir" || exit 1; GOFILE="$base" tommy generate --check; ) || status=1
-        else
-          ( cd "$dir" || exit 1; GOFILE="$base" tommy generate; ) || status=1
-        fi
-      done < <(grep -rIl --include='*.go' 'go:generate tommy generate' . 2>/dev/null | grep -v '/result' || true)
-      exit "$status"
-    '';
-  };
+  tommyCodegen = tommy.packages.${system}.conformist-tommy-codegen;
 
   # mkBatsLane wraps bats.lib.${system}.batsLane (from amarbel-llc/bats)
   # with madder's parameter shape: vanilla bats, bats-libs on

--- a/go/default.nix
+++ b/go/default.nix
@@ -48,6 +48,48 @@ let
   pkgs = import nixpkgs { inherit system; };
   pkgs-master = import nixpkgs-master { inherit system; };
 
+  # tommy codegen as a conformist linter driver. Walks the tree for
+  # `//go:generate tommy generate` directives and runs `tommy generate` per file
+  # (REPAIR mode; the conformist.toml CHECK command is a no-op `true`). Resolves
+  # tommy + go from the AMBIENT PATH and skips (exit 0) when either is missing,
+  # so it is a safe no-op where the toolchain is absent and regenerates the
+  # blob_store_configs *_tommy.go in the devshell (where tommy + go are present),
+  # landing in the `conformist --commit` chore. Exposed below so the conformistFmt
+  # wrapper in flake.nix can put it on the `nix fmt` PATH too.
+  tommyCodegen = pkgs.writeShellApplication {
+    name = "conformist-tommy-codegen";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.gnugrep
+    ];
+    text = ''
+      mode="repair"
+      if [ "''${1:-}" = "--check" ]; then
+        mode="check"
+      fi
+      if ! command -v tommy >/dev/null 2>&1; then
+        echo "tommy-codegen: tommy not on PATH; skipping" >&2
+        exit 0
+      fi
+      if ! command -v go >/dev/null 2>&1; then
+        echo "tommy-codegen: go not on PATH; skipping" >&2
+        exit 0
+      fi
+      status=0
+      while IFS= read -r f; do
+        dir=$(dirname "$f")
+        base=$(basename "$f")
+        if [ "$mode" = "check" ]; then
+          ( cd "$dir" || exit 1; GOFILE="$base" tommy generate --check; ) || status=1
+        else
+          ( cd "$dir" || exit 1; GOFILE="$base" tommy generate; ) || status=1
+        fi
+      done < <(grep -rIl --include='*.go' 'go:generate tommy generate' . 2>/dev/null | grep -v '/result' || true)
+      exit "$status"
+    '';
+  };
+
   # mkBatsLane wraps bats.lib.${system}.batsLane (from amarbel-llc/bats)
   # with madder's parameter shape: vanilla bats, bats-libs on
   # BATS_LIB_PATH, MADDER_BIN / HYPHENCE_BIN exported via the
@@ -415,6 +457,10 @@ let
   };
 in
 {
+  # Exposed so flake.nix's conformistFmt wrapper can put the codegen linter
+  # driver on the `nix fmt` PATH (it is also in the devShell below).
+  inherit tommyCodegen;
+
   packages = {
     inherit
       madder
@@ -458,6 +504,9 @@ in
       # in the devshell above.
       pkgs.nixfmt
       pkgs-master.shellcheck
+      # conformist's tommy-codegen linter driver ([linter.tommy-codegen] regen
+      # in `conformist` repair). tommy itself is already in the devshell above.
+      tommyCodegen
     ]
     ++ (with pkgs-master; [
       delve


### PR DESCRIPTION
- `conformist.toml`: add `[formatter.tommy]` (`tommy fmt` over `*.toml`) and `[linter.tommy-codegen]`. The linter's **repair** regenerates the `blob_store_configs` `*_tommy.go` via `tommy generate` so it lands in the `conformist --commit` chore; the **check is a no-op `true`** so `conformist check` never reports false codegen drift (true staleness stays gated by `just generate-tommy`).
- `go/default.nix` / `flake.nix`: put tommy + the codegen driver on the devShell and `conformistFmt` wrapper PATH so `just fmt` / `just lint-fmt` (which run conformist in the devshell) resolve both. The driver is sourced from the tommy flake (`tommy.packages.<system>.conformist-tommy-codegen`), so the pinned tommy input resolves which tommy backs it.

Depends on amarbel-llc/tommy#136. Not validated with `nix` in the authoring environment.

https://claude.ai/code/session_01HWabFkHATxynhaY8LB4wF9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWabFkHATxynhaY8LB4wF9)_